### PR TITLE
chore: project cleanup, refactor types, and add Windows setup script

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,5 +1,4 @@
 node_modules
-# Keep environment variables out of version control
 .env
-
+dist
 /src/generated/prisma

--- a/frontend/app/(app)/dashboard/page.tsx
+++ b/frontend/app/(app)/dashboard/page.tsx
@@ -1,19 +1,17 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import Link from 'next/link';
 import { Briefcase, FileText, MessageCircle, Plus } from 'lucide-react';
 
 export default function DashboardPage() {
-  const [userName, setUserName] = useState('');
-
-  useEffect(() => {
+  const [userName] = useState(() => {
     try {
-      setUserName(localStorage.getItem('prepify_username') ?? '');
+      return localStorage.getItem('prepify_username') ?? '';
     } catch {
-      setUserName('');
+      return '';
     }
-  }, []);
+  });
 
   return (
     <div>
@@ -37,7 +35,9 @@ export default function DashboardPage() {
           >
             <Briefcase className="w-5 h-5" style={{ color: '#3948CF' }} />
           </div>
-          <h3 className="font-semibold text-gray-900 dark:text-gray-100 mb-1">Job Tracking</h3>
+          <h3 className="font-semibold text-gray-900 dark:text-gray-100 mb-1">
+            Job Tracking
+          </h3>
           <p className="text-sm text-gray-500 dark:text-gray-400">
             Track applications, statuses, and follow-ups.
           </p>
@@ -54,7 +54,9 @@ export default function DashboardPage() {
           <div className="w-10 h-10 rounded-lg flex items-center justify-center mb-4 bg-gray-100 dark:bg-gray-700">
             <FileText className="w-5 h-5 text-gray-400" />
           </div>
-          <h3 className="font-semibold text-gray-900 dark:text-gray-100 mb-1">Resume Analysis</h3>
+          <h3 className="font-semibold text-gray-900 dark:text-gray-100 mb-1">
+            Resume Analysis
+          </h3>
           <p className="text-sm text-gray-500 dark:text-gray-400">
             Compare your resume against job descriptions.
           </p>
@@ -65,7 +67,9 @@ export default function DashboardPage() {
           <div className="w-10 h-10 rounded-lg flex items-center justify-center mb-4 bg-gray-100 dark:bg-gray-700">
             <MessageCircle className="w-5 h-5 text-gray-400" />
           </div>
-          <h3 className="font-semibold text-gray-900 dark:text-gray-100 mb-1">Mock Interview</h3>
+          <h3 className="font-semibold text-gray-900 dark:text-gray-100 mb-1">
+            Mock Interview
+          </h3>
           <p className="text-sm text-gray-500 dark:text-gray-400">
             Practice with AI-powered interview sessions.
           </p>

--- a/frontend/app/(app)/jobs/page.tsx
+++ b/frontend/app/(app)/jobs/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef } from 'react';
 import KanbanBoard from '../../components/jobs/KanbanBoard';
 import { useJobs, useCreateJob } from '../../hooks/useJobs';
 import demoJobs from '../../lib/demoJobs';
@@ -10,13 +10,13 @@ const isDemo = process.env.NEXT_PUBLIC_APP_MODE === 'demo';
 function DemoSeeder() {
   const { data: jobs } = useJobs();
   const createJob = useCreateJob();
-  const [seeded, setSeeded] = useState(false);
+  const seeded = useRef(false);
 
   useEffect(() => {
-    if (!isDemo || seeded || !jobs || jobs.length > 0) return;
+    if (!isDemo || seeded.current || !jobs || jobs.length > 0) return;
     demoJobs.forEach((job) => createJob.mutate(job));
-    setSeeded(true);
-  }, [jobs, seeded, createJob]);
+    seeded.current = true;
+  }, [jobs, createJob]);
 
   return null;
 }
@@ -24,8 +24,10 @@ function DemoSeeder() {
 export default function JobsPage() {
   return (
     <div className="flex flex-col h-full gap-5">
-      <div className="flex-shrink-0">
-        <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-50">Job Tracker</h1>
+      <div className="shrink-0">
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-50">
+          Job Tracker
+        </h1>
         <p className="text-sm text-gray-500 dark:text-gray-400 mt-0.5">
           Track and manage all your job applications in one place.
         </p>

--- a/frontend/app/components/jobs/AddJobModal.tsx
+++ b/frontend/app/components/jobs/AddJobModal.tsx
@@ -1,30 +1,10 @@
 'use client';
 
 import { useState } from 'react';
-import { z } from 'zod';
 import { Briefcase, MapPin, DollarSign, Link, FileText } from 'lucide-react';
 import Modal from '../ui/Modal';
-
-const STATUS_OPTIONS = ['Applied', 'Interview', 'Offer', 'Rejected'] as const;
-
-const jobSchema = z.object({
-  company: z.string().min(1, 'Company name is required'),
-  role: z.string().min(1, 'Role is required'),
-  status: z.enum(STATUS_OPTIONS),
-  location: z.string().optional(),
-  salary: z.string().optional(),
-  jobUrl: z
-    .string()
-    .optional()
-    .refine(
-      (val) => !val || val === '' || /^https?:\/\/.+/.test(val),
-      'Must be a valid URL starting with http:// or https://'
-    ),
-  notes: z.string().optional(),
-});
-
-type JobFormData = z.infer<typeof jobSchema>;
-type FieldErrors = Partial<Record<keyof JobFormData, string>>;
+import { jobSchema, STATUS_OPTIONS } from '../../lib/validations/job';
+import type { JobFormData, FieldErrors } from '../../lib/validations/job';
 
 const EMPTY_FORM: JobFormData = {
   company: '',

--- a/frontend/app/components/jobs/JobCard.tsx
+++ b/frontend/app/components/jobs/JobCard.tsx
@@ -2,7 +2,7 @@
 
 import { useDraggable } from '@dnd-kit/core';
 import { CSS } from '@dnd-kit/utilities';
-import type { Job } from '../../lib/api';
+import type { Job } from '../../types/job';
 import JobCardContent from './JobCardContent';
 
 interface JobCardProps {

--- a/frontend/app/components/jobs/JobCardContent.tsx
+++ b/frontend/app/components/jobs/JobCardContent.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useRef } from 'react';
 import { Calendar, MoreVertical, Trash2, MapPin, DollarSign, ExternalLink } from 'lucide-react';
-import type { Job } from '../../lib/api';
+import type { Job } from '../../types/job';
 
 interface JobCardContentProps {
   job: Job;

--- a/frontend/app/components/jobs/KanbanColumn.tsx
+++ b/frontend/app/components/jobs/KanbanColumn.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useDroppable } from '@dnd-kit/core';
-import type { Job } from '../../lib/api';
+import type { Job } from '../../types/job';
 import JobCard from './JobCard';
 
 export interface ColumnConfig {

--- a/frontend/app/hooks/useJobs.ts
+++ b/frontend/app/hooks/useJobs.ts
@@ -1,5 +1,6 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { jobsApi, CreateJobInput, UpdateJobInput } from '../lib/api';
+import { jobsApi } from '../lib/api';
+import type { CreateJobInput, UpdateJobInput } from '../types/job';
 
 export const JOBS_QUERY_KEY = ['jobs'] as const;
 

--- a/frontend/app/lib/api.ts
+++ b/frontend/app/lib/api.ts
@@ -1,4 +1,7 @@
 import axios from 'axios';
+import type { Job, CreateJobInput, UpdateJobInput } from '../types/job';
+
+export type { Job, CreateJobInput, UpdateJobInput };
 
 const BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001';
 
@@ -6,35 +9,6 @@ const apiClient = axios.create({
   baseURL: BASE_URL,
   headers: { 'Content-Type': 'application/json' },
 });
-
-export interface Job {
-  id: string;
-  company: string;
-  role: string;
-  status: string;
-  location: string;
-  salary: string;
-  jobUrl: string;
-  notes: string;
-  appliedAt: string;
-  createdAt: string;
-  updatedAt: string;
-}
-
-export interface CreateJobInput {
-  company: string;
-  role: string;
-  status: string;
-  location?: string;
-  salary?: string;
-  jobUrl?: string;
-  notes?: string;
-}
-
-export interface UpdateJobInput {
-  id: string;
-  data: Partial<CreateJobInput>;
-}
 
 export const jobsApi = {
   getAll: (): Promise<Job[]> =>

--- a/frontend/app/lib/validations/job.ts
+++ b/frontend/app/lib/validations/job.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod';
+
+export const STATUS_OPTIONS = ['Applied', 'Interview', 'Offer', 'Rejected'] as const;
+
+export const jobSchema = z.object({
+  company: z.string().min(1, 'Company name is required'),
+  role: z.string().min(1, 'Role is required'),
+  status: z.enum(STATUS_OPTIONS),
+  location: z.string().optional(),
+  salary: z.string().optional(),
+  jobUrl: z
+    .string()
+    .optional()
+    .refine(
+      (val) => !val || val === '' || /^https?:\/\/.+/.test(val),
+      'Must be a valid URL starting with http:// or https://'
+    ),
+  notes: z.string().optional(),
+});
+
+export type JobFormData = z.infer<typeof jobSchema>;
+export type FieldErrors = Partial<Record<keyof JobFormData, string>>;

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -9,8 +9,6 @@ import {
   Heart,
   Github,
   Eye,
-  Download,
-  Globe,
 } from 'lucide-react';
 
 const isDemo = process.env.NEXT_PUBLIC_APP_MODE === 'demo';
@@ -26,7 +24,7 @@ function MarketingHomepage({ onSeeDemo }: { onSeeDemo: () => void }) {
             Prepare smarter. Track better. Interview with confidence.
           </h2>
           <p className="text-lg text-slate-300 mb-8 max-w-2xl mx-auto leading-relaxed">
-            Your open-source desktop companion for managing job applications,
+            Your open-source companion for managing job applications,
             analyzing resumes, and practicing interviews — all in one calm,
             focused space.
           </p>
@@ -39,30 +37,6 @@ function MarketingHomepage({ onSeeDemo }: { onSeeDemo: () => void }) {
               <Eye className="w-5 h-5" />
               See Demo
             </button>
-            <div className="relative group">
-              <button
-                disabled
-                className="bg-slate-400 text-slate-200 px-8 py-3 rounded-lg font-semibold flex items-center gap-2 cursor-not-allowed opacity-60"
-              >
-                <Download className="w-5 h-5" />
-                Download App
-              </button>
-              <div className="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 px-3 py-1 bg-gray-800 text-white text-sm rounded opacity-0 group-hover:opacity-100 transition-opacity whitespace-nowrap">
-                Coming Soon
-              </div>
-            </div>
-            <div className="relative group">
-              <button
-                disabled
-                className="border-2 border-blue-300 text-blue-300 px-8 py-3 rounded-lg font-semibold flex items-center gap-2 cursor-not-allowed opacity-60"
-              >
-                <Globe className="w-5 h-5" />
-                Chrome Extension
-              </button>
-              <div className="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 px-3 py-1 bg-gray-800 text-white text-sm rounded opacity-0 group-hover:opacity-100 transition-opacity whitespace-nowrap">
-                In Development
-              </div>
-            </div>
           </div>
         </div>
       </section>

--- a/frontend/app/types/job.ts
+++ b/frontend/app/types/job.ts
@@ -1,0 +1,28 @@
+export interface Job {
+  id: string;
+  company: string;
+  role: string;
+  status: string;
+  location: string;
+  salary: string;
+  jobUrl: string;
+  notes: string;
+  appliedAt: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateJobInput {
+  company: string;
+  role: string;
+  status: string;
+  location?: string;
+  salary?: string;
+  jobUrl?: string;
+  notes?: string;
+}
+
+export interface UpdateJobInput {
+  id: string;
+  data: Partial<CreateJobInput>;
+}

--- a/setup.bat
+++ b/setup.bat
@@ -1,0 +1,91 @@
+@echo off
+setlocal EnableDelayedExpansion
+
+echo ============================================
+echo              Prepify Setup
+echo ============================================
+echo.
+
+:: ── Check Node.js ───────────────────────────
+node --version >nul 2>&1
+if %errorlevel% neq 0 (
+    echo [ERROR] Node.js is not installed.
+    echo         Download it from https://nodejs.org ^(v20 or higher^)
+    echo.
+    pause
+    exit /b 1
+)
+
+:: ── Check Git ───────────────────────────────
+git --version >nul 2>&1
+if %errorlevel% neq 0 (
+    echo [ERROR] Git is not installed.
+    echo         Download it from https://git-scm.com
+    echo.
+    pause
+    exit /b 1
+)
+
+:: ── Clone or update ─────────────────────────
+set REPO_URL=https://github.com/igagandeep/Prepify.git
+set APP_DIR=%USERPROFILE%\Prepify
+
+if exist "%APP_DIR%\.git" (
+    echo [INFO] Prepify already exists. Pulling latest changes...
+    cd /d "%APP_DIR%"
+    git pull
+) else (
+    echo [INFO] Cloning Prepify into %APP_DIR%...
+    git clone %REPO_URL% "%APP_DIR%"
+    if %errorlevel% neq 0 (
+        echo [ERROR] Failed to clone repository.
+        pause
+        exit /b 1
+    )
+    cd /d "%APP_DIR%"
+)
+
+:: ── Install dependencies ─────────────────────
+echo.
+echo [INFO] Installing dependencies...
+npm install --legacy-peer-deps
+if %errorlevel% neq 0 (
+    echo [ERROR] Dependency installation failed.
+    pause
+    exit /b 1
+)
+
+:: ── Backend .env ─────────────────────────────
+if not exist "backend\.env" (
+    echo [INFO] Creating backend environment file...
+    (
+        echo DATABASE_URL=file:./prepify.db
+        echo NODE_ENV=development
+    ) > backend\.env
+)
+
+:: ── Database setup ───────────────────────────
+echo.
+echo [INFO] Setting up database...
+cd backend
+npx prisma db push
+if %errorlevel% neq 0 (
+    echo [ERROR] Database setup failed.
+    cd ..
+    pause
+    exit /b 1
+)
+cd ..
+
+:: ── Launch ───────────────────────────────────
+echo.
+echo ============================================
+echo   Prepify is starting!
+echo.
+echo   Frontend → http://localhost:3000
+echo   Backend  → http://localhost:3001
+echo.
+echo   Press Ctrl+C to stop.
+echo ============================================
+echo.
+npm run dev


### PR DESCRIPTION
- Remove dead Electron build workflow and User Prisma model
- Remove unused babel-plugin-react-compiler and @/* path alias
- Add dist/ to backend .gitignore
- Extract job types to app/types/job.ts and Zod schema to app/lib/validations/job.ts
- Fix React lint warnings: replace setState-in-effect with lazy useState and useRef
- Remove Download App and Chrome Extension buttons from homepage
- Update README and hero text to remove Electron/desktop references
- Add setup.bat for one-click Windows install and launch