### PR TITLE
fix: improve Chrome extension LinkedIn job scraping and button placement

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -3,12 +3,22 @@ var BUTTON_ID = 'prepify-save-btn';
 var API_URL = 'http://localhost:5000/api/jobs';
 var lastUrl = '';
 
+function isLinkedIn() {
+  var h = location.hostname;
+  return h === 'www.linkedin.com' || h === 'linkedin.com' || h.endsWith('.linkedin.com');
+}
+
+function isIndeed() {
+  var h = location.hostname;
+  return h === 'www.indeed.com' || h === 'indeed.com' || h.endsWith('.indeed.com');
+}
+
 function isJobPage() {
   var url = location.href;
-  if (location.hostname.includes('linkedin.com')) {
+  if (isLinkedIn()) {
     return url.includes('/jobs/') && url.includes('currentJobId=');
   }
-  if (location.hostname.includes('indeed.com')) {
+  if (isIndeed()) {
     return url.includes('/viewjob') || url.includes('/rc/clk') || url.includes('vjk=');
   }
   return false;
@@ -101,8 +111,8 @@ function scrapeIndeed() {
 }
 
 function scrapeJobData() {
-  if (location.hostname.includes('linkedin.com')) return scrapeLinkedIn();
-  if (location.hostname.includes('indeed.com')) return scrapeIndeed();
+  if (isLinkedIn()) return scrapeLinkedIn();
+  if (isIndeed()) return scrapeIndeed();
   return { role: '', company: '', location: '', notes: '' };
 }
 
@@ -178,8 +188,7 @@ function removePanel() {
 
 function showPanel(data) {
   removePanel();
-  var platform = location.hostname.includes('linkedin.com') ? 'LinkedIn' :
-                 location.hostname.includes('indeed.com') ? 'Indeed' : 'Job';
+  var platform = isLinkedIn() ? 'LinkedIn' : isIndeed() ? 'Indeed' : 'Job';
 
   var jobUrl = location.href;
   if (jobUrl.includes('/jobs/collections/') && jobUrl.includes('currentJobId=')) {

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -36,15 +36,6 @@
         "https://www.linkedin.com/*",
         "https://*.indeed.com/*"
       ],
-      "js": ["scraper.js"],
-      "run_at": "document_idle",
-      "world": "MAIN"
-    },
-    {
-      "matches": [
-        "https://www.linkedin.com/*",
-        "https://*.indeed.com/*"
-      ],
       "js": ["content.js"],
       "run_at": "document_idle"
     }


### PR DESCRIPTION
## Summary
- Fix empty form fields when scraping LinkedIn jobs during SPA navigation
- Scope scraper to job detail pane to avoid grabbing wrong data from sidebar
- Place "Prepify" button next to LinkedIn's native Save button
- Disable extension on `/jobs/view/` URLs
- Remove unused `scraper.js` from manifest

## Changes
- **`extension/content.js`** — Rewrote scraper selectors, added retry logic, injected button next to Save button
- **`extension/manifest.json`** — Removed `scraper.js` entry

## Test plan
- [ ] Navigate to LinkedIn Jobs collections page with `currentJobId=` in URL
- [ ] Verify "+ Prepify" button appears next to Save button
- [ ] Click button and confirm form fields are populated
- [ ] Submit form and verify job is saved to Prepify
- [ ] Verify button does NOT appear on `/jobs/view/` pages
- [ ] Verify SPA navigation between jobs updates the scraped data
