### PR TITLE
feat: build Mock Interview UI with mock data simulation (#46)

### DIFF
--- a/frontend/app/(app)/dashboard/page.tsx
+++ b/frontend/app/(app)/dashboard/page.tsx
@@ -75,9 +75,15 @@ export default function DashboardPage() {
           </div>
         </Link>
 
-        <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl p-6 opacity-60">
-          <div className="w-10 h-10 rounded-lg flex items-center justify-center mb-4 bg-gray-100 dark:bg-gray-700">
-            <MessageCircle className="w-5 h-5 text-gray-400" />
+        <Link
+          href="/interview"
+          className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl p-6 text-left hover:border-indigo-300 dark:hover:border-indigo-500 hover:shadow-sm transition-all block"
+        >
+          <div
+            className="w-10 h-10 rounded-lg flex items-center justify-center mb-4"
+            style={{ backgroundColor: '#EEF0FD' }}
+          >
+            <MessageCircle className="w-5 h-5" style={{ color: '#3948CF' }} />
           </div>
           <h3 className="font-semibold text-gray-900 dark:text-gray-100 mb-1">
             Mock Interview
@@ -85,8 +91,14 @@ export default function DashboardPage() {
           <p className="text-sm text-gray-500 dark:text-gray-400">
             Practice with AI-powered interview sessions.
           </p>
-          <p className="mt-4 text-sm text-gray-400">Coming soon</p>
-        </div>
+          <div
+            className="mt-4 flex items-center gap-1 text-sm font-medium"
+            style={{ color: '#3948CF' }}
+          >
+            <ArrowRight className="w-4 h-4" />
+            Start session
+          </div>
+        </Link>
       </div>
     </div>
   );

--- a/frontend/app/(app)/interview/page.tsx
+++ b/frontend/app/(app)/interview/page.tsx
@@ -1,8 +1,179 @@
-export default function InterviewPage() {
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { MessageCircle, ChevronDown } from 'lucide-react';
+import type { InterviewType, Difficulty, QuestionCount } from '../../lib/interview/mockData';
+
+interface FormState {
+  role: string;
+  type: InterviewType;
+  count: QuestionCount;
+  difficulty: Difficulty;
+}
+
+interface FormErrors {
+  role?: string;
+}
+
+export default function InterviewSetupPage() {
+  const router = useRouter();
+
+  const [form, setForm] = useState<FormState>({
+    role: '',
+    type: 'Technical',
+    count: 5,
+    difficulty: 'Medium',
+  });
+  const [errors, setErrors] = useState<FormErrors>({});
+
+  function validate(): boolean {
+    const errs: FormErrors = {};
+    if (!form.role.trim()) errs.role = 'Job role is required';
+    setErrors(errs);
+    return Object.keys(errs).length === 0;
+  }
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!validate()) return;
+
+    const params = new URLSearchParams({
+      role: form.role.trim(),
+      type: form.type,
+      count: String(form.count),
+      difficulty: form.difficulty,
+    });
+    router.push(`/interview/session?${params.toString()}`);
+  }
+
+  const selectClass =
+    'w-full appearance-none px-3 py-2.5 border border-gray-200 dark:border-gray-600 rounded-lg text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:outline-none focus:border-[#3948CF] transition-colors pr-9';
+
   return (
-    <div>
-      <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-50 mb-2">Mock Interview</h1>
-      <p className="text-gray-500 dark:text-gray-400 text-sm">This feature is coming soon.</p>
+    <div className="max-w-lg mx-auto">
+      {/* Page header */}
+      <div className="mb-8">
+        <div
+          className="w-10 h-10 rounded-lg flex items-center justify-center mb-4"
+          style={{ backgroundColor: '#EEF0FD' }}
+        >
+          <MessageCircle className="w-5 h-5" style={{ color: '#3948CF' }} />
+        </div>
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-50">Mock Interview</h1>
+        <p className="text-gray-500 dark:text-gray-400 text-sm mt-1">
+          Configure your AI-powered interview session and receive personalised feedback.
+        </p>
+      </div>
+
+      {/* Form card */}
+      <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl p-6">
+        <form onSubmit={handleSubmit} noValidate className="space-y-5">
+          {/* Job Role */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1.5">
+              Job Role <span className="text-red-500">*</span>
+            </label>
+            <input
+              type="text"
+              value={form.role}
+              onChange={(e) => {
+                setForm((f) => ({ ...f, role: e.target.value }));
+                if (errors.role) setErrors((err) => ({ ...err, role: undefined }));
+              }}
+              placeholder="e.g. Software Engineer, Product Manager"
+              className={`w-full px-3 py-2.5 border rounded-lg text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none transition-colors ${
+                errors.role
+                  ? 'border-red-400 dark:border-red-500 focus:border-red-400'
+                  : 'border-gray-200 dark:border-gray-600 focus:border-[#3948CF]'
+              }`}
+            />
+            {errors.role && (
+              <p className="mt-1.5 text-xs text-red-500">{errors.role}</p>
+            )}
+          </div>
+
+          {/* Interview Type */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1.5">
+              Interview Type
+            </label>
+            <div className="relative">
+              <select
+                value={form.type}
+                onChange={(e) =>
+                  setForm((f) => ({ ...f, type: e.target.value as InterviewType }))
+                }
+                className={selectClass}
+              >
+                <option value="Technical">Technical</option>
+                <option value="Behavioral">Behavioral</option>
+                <option value="Mixed">Mixed</option>
+              </select>
+              <ChevronDown className="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400 pointer-events-none" />
+            </div>
+            <p className="mt-1.5 text-xs text-gray-400 dark:text-gray-500">
+              {form.type === 'Technical' && 'System design, algorithms, and coding concepts.'}
+              {form.type === 'Behavioral' && 'Situational and competency-based questions.'}
+              {form.type === 'Mixed' && 'A blend of technical and behavioural questions.'}
+            </p>
+          </div>
+
+          {/* Number of Questions */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1.5">
+              Number of Questions
+            </label>
+            <div className="relative">
+              <select
+                value={form.count}
+                onChange={(e) =>
+                  setForm((f) => ({ ...f, count: Number(e.target.value) as QuestionCount }))
+                }
+                className={selectClass}
+              >
+                <option value={5}>5 Questions (~10 min)</option>
+                <option value={10}>10 Questions (~20 min)</option>
+                <option value={15}>15 Questions (~30 min)</option>
+              </select>
+              <ChevronDown className="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400 pointer-events-none" />
+            </div>
+          </div>
+
+          {/* Difficulty */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1.5">
+              Difficulty
+            </label>
+            {/* Segmented control */}
+            <div className="flex border border-gray-200 dark:border-gray-600 rounded-lg overflow-hidden">
+              {(['Easy', 'Medium', 'Hard'] as Difficulty[]).map((level) => (
+                <button
+                  key={level}
+                  type="button"
+                  onClick={() => setForm((f) => ({ ...f, difficulty: level }))}
+                  className={`flex-1 py-2.5 text-sm font-medium transition-colors ${
+                    form.difficulty === level
+                      ? 'text-white'
+                      : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 bg-white dark:bg-gray-700'
+                  }`}
+                  style={form.difficulty === level ? { backgroundColor: '#3948CF' } : {}}
+                >
+                  {level}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <button
+            type="submit"
+            className="w-full py-2.5 rounded-xl text-white font-semibold text-sm transition-opacity hover:opacity-90 mt-2"
+            style={{ backgroundColor: '#3948CF' }}
+          >
+            Start Session
+          </button>
+        </form>
+      </div>
     </div>
   );
 }

--- a/frontend/app/(app)/interview/results/page.tsx
+++ b/frontend/app/(app)/interview/results/page.tsx
@@ -1,0 +1,319 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import Link from 'next/link';
+import {
+  CheckCircle,
+  TrendingUp,
+  Award,
+  ChevronDown,
+  ChevronUp,
+  RotateCcw,
+  LayoutDashboard,
+} from 'lucide-react';
+import {
+  DEMO_RESULTS,
+  type MockResults,
+  type SessionResult,
+  type RatingLevel,
+} from '../../../lib/interview/mockData';
+import CircularScore from '../../../components/interview/CircularScore';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function scoreToColor(score: number): string {
+  return score >= 8 ? '#22c55e' : score >= 6 ? '#f59e0b' : '#ef4444';
+}
+
+function recommendationStyles(overall: number): string {
+  if (overall >= 80)
+    return 'bg-green-50 dark:bg-green-900/20 text-green-700 dark:text-green-400 border border-green-200 dark:border-green-800';
+  if (overall >= 60)
+    return 'bg-amber-50 dark:bg-amber-900/20 text-amber-700 dark:text-amber-400 border border-amber-200 dark:border-amber-800';
+  return 'bg-red-50 dark:bg-red-900/20 text-red-700 dark:text-red-400 border border-red-200 dark:border-red-800';
+}
+
+const RATING_COLORS: Record<RatingLevel, string> = {
+  High: 'bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-400',
+  Medium: 'bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-400',
+  Low: 'bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-400',
+};
+
+// ─── Question breakdown accordion item ───────────────────────────────────────
+
+function QuestionCard({
+  result,
+  index,
+  isExpanded,
+  onToggle,
+}: {
+  result: SessionResult;
+  index: number;
+  isExpanded: boolean;
+  onToggle: () => void;
+}) {
+  const fb = result.feedback;
+  const color = scoreToColor(fb.score);
+
+  return (
+    <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl overflow-hidden">
+      {/* Header row */}
+      <button
+        onClick={onToggle}
+        className="w-full flex items-center gap-3 p-4 text-left hover:bg-gray-50 dark:hover:bg-gray-700/40 transition-colors"
+      >
+        {/* Question number */}
+        <div
+          className="w-7 h-7 rounded-full flex items-center justify-center text-white text-xs font-bold shrink-0"
+          style={{ backgroundColor: '#3948CF' }}
+        >
+          {index + 1}
+        </div>
+
+        {/* Question text */}
+        <p className="flex-1 min-w-0 text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
+          {result.question}
+        </p>
+
+        {/* Score + chevron */}
+        <div className="flex items-center gap-3 shrink-0">
+          <span className="text-sm font-bold" style={{ color }}>
+            {fb.score}/10
+          </span>
+          {isExpanded ? (
+            <ChevronUp className="w-4 h-4 text-gray-400" />
+          ) : (
+            <ChevronDown className="w-4 h-4 text-gray-400" />
+          )}
+        </div>
+      </button>
+
+      {/* Expanded body */}
+      {isExpanded && (
+        <div className="border-t border-gray-100 dark:border-gray-700 p-4 space-y-4">
+          {/* User answer */}
+          <div>
+            <p className="text-xs font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wide mb-1.5">
+              Your Answer
+            </p>
+            <p className="text-sm text-gray-700 dark:text-gray-300 leading-relaxed bg-gray-50 dark:bg-gray-700/50 rounded-lg px-3 py-2.5">
+              {result.userAnswer}
+            </p>
+          </div>
+
+          {/* Accuracy / Clarity badges */}
+          <div className="flex items-center gap-3">
+            {(['accuracy', 'clarity'] as const).map((key) => {
+              const val = fb[key] as RatingLevel;
+              return (
+                <div key={key} className="flex items-center gap-1.5">
+                  <span className="text-xs text-gray-500 dark:text-gray-400 capitalize">
+                    {key}:
+                  </span>
+                  <span className={`text-xs font-medium px-2 py-0.5 rounded-full ${RATING_COLORS[val]}`}>
+                    {val}
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+
+          {/* Strengths + Improvements */}
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <p className="text-xs font-semibold text-green-600 dark:text-green-400 mb-1.5">
+                Strengths
+              </p>
+              <ul className="space-y-1">
+                {fb.strengths.map((s, i) => (
+                  <li
+                    key={i}
+                    className="flex items-start gap-1.5 text-xs text-gray-600 dark:text-gray-400"
+                  >
+                    <span className="mt-1 w-1 h-1 rounded-full bg-green-400 shrink-0" />
+                    {s}
+                  </li>
+                ))}
+              </ul>
+            </div>
+
+            <div>
+              <p className="text-xs font-semibold text-amber-600 dark:text-amber-400 mb-1.5">
+                Improvements
+              </p>
+              <ul className="space-y-1">
+                {fb.improvements.map((s, i) => (
+                  <li
+                    key={i}
+                    className="flex items-start gap-1.5 text-xs text-gray-600 dark:text-gray-400"
+                  >
+                    <span className="mt-1 w-1 h-1 rounded-full bg-amber-400 shrink-0" />
+                    {s}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Page ─────────────────────────────────────────────────────────────────────
+
+export default function InterviewResultsPage() {
+  const [results, setResults] = useState<MockResults>(DEMO_RESULTS);
+  const [expandedIndex, setExpandedIndex] = useState<number | null>(0);
+
+  // Try to load real session results from sessionStorage
+  useEffect(() => {
+    try {
+      const stored = sessionStorage.getItem('prepify_interview_results');
+      if (!stored) return;
+
+      const parsed = JSON.parse(stored) as {
+        results: SessionResult[];
+        role?: string;
+        type?: string;
+      };
+
+      if (!parsed.results || parsed.results.length === 0) return;
+
+      const totalScore = parsed.results.reduce((sum, r) => sum + r.feedback.score, 0);
+      const overallScore = Math.round((totalScore / parsed.results.length) * 10);
+
+      setResults({
+        ...DEMO_RESULTS,
+        overallScore,
+        questions: parsed.results,
+      });
+    } catch {
+      // Fall back to demo data
+    }
+  }, []);
+
+  function toggleExpanded(i: number) {
+    setExpandedIndex((prev) => (prev === i ? null : i));
+  }
+
+  return (
+    <div>
+      {/* Page header */}
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-50">
+            Interview Results
+          </h1>
+          <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+            Here&apos;s a detailed breakdown of your performance.
+          </p>
+        </div>
+
+        <div className="flex items-center gap-3">
+          <Link
+            href="/dashboard"
+            className="flex items-center gap-2 px-4 py-2 rounded-lg border border-gray-200 dark:border-gray-700 text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
+          >
+            <LayoutDashboard className="w-4 h-4" />
+            Dashboard
+          </Link>
+          <Link
+            href="/interview"
+            className="flex items-center gap-2 px-4 py-2 rounded-xl text-sm font-semibold text-white transition-opacity hover:opacity-90"
+            style={{ backgroundColor: '#3948CF' }}
+          >
+            <RotateCcw className="w-4 h-4" />
+            Try Again
+          </Link>
+        </div>
+      </div>
+
+      {/* Two-column layout: summary left, breakdown right */}
+      <div className="grid grid-cols-5 gap-5 items-start">
+        {/* ── Left: summary column (2/5) ── */}
+        <div className="col-span-2 space-y-4">
+          {/* Score card */}
+          <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl p-6 flex flex-col items-center text-center">
+            <CircularScore score={results.overallScore} size={140} />
+            <p className="mt-3 text-sm font-semibold text-gray-900 dark:text-gray-100">
+              Overall Score
+            </p>
+            <div
+              className={`mt-3 inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium ${recommendationStyles(results.overallScore)}`}
+            >
+              <Award className="w-3.5 h-3.5 shrink-0" />
+              {results.recommendation}
+            </div>
+          </div>
+
+          {/* Summary */}
+          <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl p-5">
+            <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-2">
+              Summary
+            </h3>
+            <p className="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">
+              {results.summary}
+            </p>
+          </div>
+
+          {/* Top Strengths */}
+          <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl p-5">
+            <div className="flex items-center gap-2 mb-3">
+              <div className="w-7 h-7 rounded-md flex items-center justify-center bg-green-50 dark:bg-green-900/20 shrink-0">
+                <CheckCircle className="w-3.5 h-3.5 text-green-600 dark:text-green-400" />
+              </div>
+              <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">
+                Top Strengths
+              </h3>
+            </div>
+            <ul className="space-y-2">
+              {results.topStrengths.map((s, i) => (
+                <li key={i} className="flex items-start gap-2 text-sm text-gray-600 dark:text-gray-400">
+                  <span className="mt-1.5 w-1.5 h-1.5 rounded-full bg-green-500 shrink-0" />
+                  {s}
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          {/* Areas to Improve */}
+          <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl p-5">
+            <div className="flex items-center gap-2 mb-3">
+              <div className="w-7 h-7 rounded-md flex items-center justify-center bg-amber-50 dark:bg-amber-900/20 shrink-0">
+                <TrendingUp className="w-3.5 h-3.5 text-amber-600 dark:text-amber-400" />
+              </div>
+              <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">
+                Areas to Improve
+              </h3>
+            </div>
+            <ul className="space-y-2">
+              {results.areasToImprove.map((s, i) => (
+                <li key={i} className="flex items-start gap-2 text-sm text-gray-600 dark:text-gray-400">
+                  <span className="mt-1.5 w-1.5 h-1.5 rounded-full bg-amber-500 shrink-0" />
+                  {s}
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+
+        {/* ── Right: per-question breakdown (3/5) ── */}
+        <div className="col-span-3 space-y-3">
+          <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">
+            Question Breakdown
+          </h3>
+          {results.questions.map((q, i) => (
+            <QuestionCard
+              key={q.id}
+              result={q}
+              index={i}
+              isExpanded={expandedIndex === i}
+              onToggle={() => toggleExpanded(i)}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/(app)/interview/session/page.tsx
+++ b/frontend/app/(app)/interview/session/page.tsx
@@ -1,0 +1,333 @@
+'use client';
+
+import { useState, useRef, useEffect, Suspense } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { Bot, User, PlayCircle, ChevronRight, Flag } from 'lucide-react';
+import {
+  getMockQuestions,
+  type MockQuestion,
+  type InterviewType,
+  type QuestionCount,
+  type Difficulty,
+  type SessionResult,
+  type AnswerFeedback,
+} from '../../../lib/interview/mockData';
+import FeedbackPanel from '../../../components/interview/FeedbackPanel';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+type SessionPhase = 'idle' | 'asking' | 'submitted' | 'completed';
+
+interface ChatMessage {
+  id: string;
+  role: 'ai' | 'user';
+  content: string;
+}
+
+// ─── Inner component (needs useSearchParams, so wrapped in Suspense) ──────────
+
+function SessionContent() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const role = searchParams.get('role') ?? 'Software Engineer';
+  const type = (searchParams.get('type') as InterviewType) ?? 'Technical';
+  const count = (Number(searchParams.get('count') ?? 5)) as QuestionCount;
+  const difficulty = (searchParams.get('difficulty') as Difficulty) ?? 'Medium';
+
+  const questions: MockQuestion[] = getMockQuestions(type, count);
+  const totalQuestions = questions.length;
+
+  const [phase, setPhase] = useState<SessionPhase>('idle');
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [userAnswer, setUserAnswer] = useState('');
+  const [results, setResults] = useState<SessionResult[]>([]);
+  const [activeFeedback, setActiveFeedback] = useState<AnswerFeedback | null>(null);
+  const [activeFeedbackIndex, setActiveFeedbackIndex] = useState(0);
+
+  const [messages, setMessages] = useState<ChatMessage[]>([
+    {
+      id: 'intro',
+      role: 'ai',
+      content: `Hi! I'm your AI interview assistant for today's session. You'll be answering ${totalQuestions} ${difficulty.toLowerCase()}-difficulty ${type.toLowerCase()} interview question${totalQuestions !== 1 ? 's' : ''} for a ${role} role. Take your time with each answer — I'll provide feedback after every response. Click "Start Interview" whenever you're ready.`,
+    },
+  ]);
+
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages]);
+
+  useEffect(() => {
+    if (phase === 'asking') {
+      textareaRef.current?.focus();
+    }
+  }, [phase]);
+
+  // ── Actions ──────────────────────────────────────────────────────────────────
+
+  function startInterview() {
+    setPhase('asking');
+    setCurrentIndex(0);
+    setMessages((prev) => [
+      ...prev,
+      { id: 'q-0', role: 'ai', content: questions[0].question },
+    ]);
+  }
+
+  function submitAnswer() {
+    const answer = userAnswer.trim() || '(No answer provided)';
+    const q = questions[currentIndex];
+
+    setMessages((prev) => [
+      ...prev,
+      { id: `a-${currentIndex}`, role: 'user', content: answer },
+    ]);
+
+    const result: SessionResult = { ...q, userAnswer: answer };
+    setResults((prev) => [...prev, result]);
+    setActiveFeedback(q.feedback);
+    setActiveFeedbackIndex(currentIndex + 1);
+    setPhase('submitted');
+    setUserAnswer('');
+  }
+
+  function nextQuestion() {
+    const nextIndex = currentIndex + 1;
+
+    if (nextIndex >= totalQuestions) {
+      setPhase('completed');
+      setMessages((prev) => [
+        ...prev,
+        {
+          id: 'done',
+          role: 'ai',
+          content: `Well done on completing all ${totalQuestions} question${totalQuestions !== 1 ? 's' : ''}! Click "View Results" below to see your full performance report.`,
+        },
+      ]);
+      return;
+    }
+
+    setCurrentIndex(nextIndex);
+    setPhase('asking');
+    setMessages((prev) => [
+      ...prev,
+      { id: `q-${nextIndex}`, role: 'ai', content: questions[nextIndex].question },
+    ]);
+  }
+
+  function viewResults() {
+    try {
+      sessionStorage.setItem(
+        'prepify_interview_results',
+        JSON.stringify({ role, type, count, difficulty, results })
+      );
+    } catch {
+      // sessionStorage unavailable — results page falls back to demo data
+    }
+    router.push('/interview/results');
+  }
+
+  // ── Progress dots ─────────────────────────────────────────────────────────────
+
+  const answeredCount = results.length;
+
+  // ── Render ────────────────────────────────────────────────────────────────────
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* Page header */}
+      <div className="flex items-center justify-between shrink-0">
+        <div>
+          <h1 className="text-xl font-bold text-gray-900 dark:text-gray-50">
+            {role}
+            <span className="font-normal text-gray-400 dark:text-gray-500"> — </span>
+            {type} Interview
+          </h1>
+          <p className="text-sm text-gray-500 dark:text-gray-400 mt-0.5">
+            {difficulty} difficulty
+          </p>
+        </div>
+
+        {/* Progress indicator */}
+        {phase !== 'idle' && (
+          <div className="flex items-center gap-3">
+            <span className="text-sm text-gray-500 dark:text-gray-400 tabular-nums">
+              Question {Math.min(currentIndex + 1, totalQuestions)} of {totalQuestions}
+            </span>
+            <div className="flex items-center gap-1">
+              {questions.map((_, i) => {
+                const isDone = i < answeredCount;
+                const isCurrent = i === currentIndex && phase !== 'idle';
+                return (
+                  <div
+                    key={i}
+                    className={`w-2 h-2 rounded-full transition-colors duration-300 ${
+                      !isDone && !isCurrent ? 'bg-gray-200 dark:bg-gray-600' : ''
+                    }`}
+                    style={{
+                      backgroundColor: isDone
+                        ? '#3948CF'
+                        : isCurrent
+                        ? '#93A3F8'
+                        : undefined,
+                    }}
+                  />
+                );
+              })}
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Two-column layout */}
+      <div className="flex gap-4 items-start">
+        {/* ── Chat column ── */}
+        <div className="flex-1 min-w-0 flex flex-col bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl overflow-hidden">
+          {/* Messages area */}
+          <div
+            className="overflow-y-auto p-5 space-y-5 flex-1"
+            style={{ height: 'calc(100vh - 340px)', minHeight: '320px' }}
+          >
+            {messages.map((msg) => (
+              <div
+                key={msg.id}
+                className={`flex gap-3 ${msg.role === 'user' ? 'flex-row-reverse' : ''}`}
+              >
+                {/* Avatar */}
+                <div
+                  className={`w-8 h-8 rounded-full flex items-center justify-center shrink-0 ${
+                    msg.role === 'ai'
+                      ? 'bg-[#EEF0FD]'
+                      : 'bg-gray-100 dark:bg-gray-700'
+                  }`}
+                >
+                  {msg.role === 'ai' ? (
+                    <Bot className="w-4 h-4" style={{ color: '#3948CF' }} />
+                  ) : (
+                    <User className="w-4 h-4 text-gray-500 dark:text-gray-400" />
+                  )}
+                </div>
+
+                {/* Bubble */}
+                <div
+                  className={`max-w-[78%] px-4 py-3 rounded-2xl text-sm leading-relaxed ${
+                    msg.role === 'ai'
+                      ? 'bg-gray-50 dark:bg-gray-700/60 text-gray-800 dark:text-gray-100 rounded-tl-sm'
+                      : 'text-white rounded-tr-sm'
+                  }`}
+                  style={msg.role === 'user' ? { backgroundColor: '#3948CF' } : {}}
+                >
+                  {msg.content}
+                </div>
+              </div>
+            ))}
+
+            <div ref={messagesEndRef} />
+          </div>
+
+          {/* Bottom action bar */}
+          <div className="border-t border-gray-100 dark:border-gray-700 p-4">
+            {phase === 'idle' && (
+              <button
+                onClick={startInterview}
+                className="flex items-center gap-2 px-5 py-2.5 rounded-xl text-white text-sm font-semibold transition-opacity hover:opacity-90"
+                style={{ backgroundColor: '#3948CF' }}
+              >
+                <PlayCircle className="w-4 h-4" />
+                Start Interview
+              </button>
+            )}
+
+            {phase === 'asking' && (
+              <div className="space-y-3">
+                <textarea
+                  ref={textareaRef}
+                  value={userAnswer}
+                  onChange={(e) => setUserAnswer(e.target.value)}
+                  onKeyDown={(e) => {
+                    // Ctrl/Cmd+Enter submits
+                    if ((e.ctrlKey || e.metaKey) && e.key === 'Enter' && userAnswer.trim()) {
+                      e.preventDefault();
+                      submitAnswer();
+                    }
+                  }}
+                  rows={4}
+                  placeholder="Type your answer here… (Ctrl+Enter to submit)"
+                  className="w-full px-3 py-2.5 border border-gray-200 dark:border-gray-600 rounded-lg text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:border-[#3948CF] resize-none transition-colors"
+                />
+                <button
+                  onClick={submitAnswer}
+                  disabled={!userAnswer.trim()}
+                  className="px-5 py-2.5 rounded-xl text-white text-sm font-semibold transition-opacity hover:opacity-90 disabled:opacity-40 disabled:cursor-not-allowed"
+                  style={{ backgroundColor: '#3948CF' }}
+                >
+                  Submit Answer
+                </button>
+              </div>
+            )}
+
+            {phase === 'submitted' && currentIndex < totalQuestions - 1 && (
+              <button
+                onClick={nextQuestion}
+                className="flex items-center gap-2 px-5 py-2.5 rounded-xl text-white text-sm font-semibold transition-opacity hover:opacity-90"
+                style={{ backgroundColor: '#3948CF' }}
+              >
+                Next Question
+                <ChevronRight className="w-4 h-4" />
+              </button>
+            )}
+
+            {phase === 'submitted' && currentIndex === totalQuestions - 1 && (
+              <button
+                onClick={nextQuestion}
+                className="flex items-center gap-2 px-5 py-2.5 rounded-xl text-white text-sm font-semibold transition-opacity hover:opacity-90"
+                style={{ backgroundColor: '#3948CF' }}
+              >
+                <Flag className="w-4 h-4" />
+                Finish Interview
+              </button>
+            )}
+
+            {phase === 'completed' && (
+              <button
+                onClick={viewResults}
+                className="flex items-center gap-2 px-5 py-2.5 rounded-xl text-white text-sm font-semibold transition-opacity hover:opacity-90"
+                style={{ backgroundColor: '#3948CF' }}
+              >
+                View Results
+                <ChevronRight className="w-4 h-4" />
+              </button>
+            )}
+          </div>
+        </div>
+
+        {/* ── Feedback sidebar ── */}
+        <div className="w-72 shrink-0">
+          <FeedbackPanel
+            feedback={activeFeedback}
+            questionNumber={activeFeedbackIndex}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─── Page export (Suspense required for useSearchParams in static export) ─────
+
+export default function InterviewSessionPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex items-center justify-center h-64">
+          <p className="text-sm text-gray-400 dark:text-gray-500">Loading session…</p>
+        </div>
+      }
+    >
+      <SessionContent />
+    </Suspense>
+  );
+}

--- a/frontend/app/(app)/interview/session/page.tsx
+++ b/frontend/app/(app)/interview/session/page.tsx
@@ -160,7 +160,7 @@ function SessionContent() {
             <div className="flex items-center gap-1">
               {questions.map((_, i) => {
                 const isDone = i < answeredCount;
-                const isCurrent = i === currentIndex && phase !== 'idle';
+                const isCurrent = i === currentIndex;
                 return (
                   <div
                     key={i}

--- a/frontend/app/(app)/layout.tsx
+++ b/frontend/app/(app)/layout.tsx
@@ -63,7 +63,7 @@ export default function AppShellLayout({ children }: { children: React.ReactNode
 
           <nav className="flex-1 p-3 space-y-0.5">
             {NAV_ITEMS.map(({ href, label, icon: Icon }) => {
-              const isActive = pathname === href;
+              const isActive = pathname === href || pathname.startsWith(href + '/');
               return (
                 <Link
                   key={href}

--- a/frontend/app/components/interview/CircularScore.tsx
+++ b/frontend/app/components/interview/CircularScore.tsx
@@ -1,0 +1,59 @@
+interface CircularScoreProps {
+  score: number; // 0–100
+  size?: number;
+}
+
+export default function CircularScore({ score, size = 140 }: CircularScoreProps) {
+  const strokeWidth = 10;
+  const radius = (size - strokeWidth * 2) / 2;
+  const circumference = 2 * Math.PI * radius;
+  const offset = circumference - (Math.min(100, Math.max(0, score)) / 100) * circumference;
+  const cx = size / 2;
+  const cy = size / 2;
+
+  const strokeColor =
+    score >= 80 ? '#22c55e' : score >= 60 ? '#f59e0b' : '#ef4444';
+
+  return (
+    <div className="relative inline-flex items-center justify-center">
+      <svg
+        width={size}
+        height={size}
+        style={{ transform: 'rotate(-90deg)' }}
+        aria-hidden="true"
+      >
+        {/* Track */}
+        <circle
+          cx={cx}
+          cy={cy}
+          r={radius}
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={strokeWidth}
+          className="text-gray-100 dark:text-gray-700"
+        />
+        {/* Progress */}
+        <circle
+          cx={cx}
+          cy={cy}
+          r={radius}
+          fill="none"
+          stroke={strokeColor}
+          strokeWidth={strokeWidth}
+          strokeLinecap="round"
+          strokeDasharray={circumference}
+          strokeDashoffset={offset}
+          style={{ transition: 'stroke-dashoffset 0.7s ease' }}
+        />
+      </svg>
+
+      {/* Label */}
+      <div className="absolute inset-0 flex flex-col items-center justify-center">
+        <span className="text-3xl font-bold text-gray-900 dark:text-gray-50 leading-none">
+          {score}
+        </span>
+        <span className="text-xs text-gray-400 dark:text-gray-500 mt-0.5">/ 100</span>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/components/interview/FeedbackPanel.tsx
+++ b/frontend/app/components/interview/FeedbackPanel.tsx
@@ -1,0 +1,117 @@
+import { CheckCircle, TrendingUp } from 'lucide-react';
+import type { AnswerFeedback, RatingLevel } from '../../lib/interview/mockData';
+
+interface FeedbackPanelProps {
+  feedback: AnswerFeedback | null;
+  questionNumber: number;
+}
+
+function RatingBadge({ label, value }: { label: string; value: RatingLevel }) {
+  const colorMap: Record<RatingLevel, string> = {
+    High: 'bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-400',
+    Medium: 'bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-400',
+    Low: 'bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-400',
+  };
+
+  return (
+    <div className="flex items-center justify-between">
+      <span className="text-xs text-gray-500 dark:text-gray-400">{label}</span>
+      <span className={`text-xs font-medium px-2 py-0.5 rounded-full ${colorMap[value]}`}>
+        {value}
+      </span>
+    </div>
+  );
+}
+
+export default function FeedbackPanel({ feedback, questionNumber }: FeedbackPanelProps) {
+  if (!feedback) {
+    return (
+      <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl p-5">
+        <div className="flex items-center gap-2 mb-3">
+          <div
+            className="w-7 h-7 rounded-md flex items-center justify-center"
+            style={{ backgroundColor: '#EEF0FD' }}
+          >
+            <TrendingUp className="w-3.5 h-3.5" style={{ color: '#3948CF' }} />
+          </div>
+          <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">
+            Answer Feedback
+          </h3>
+        </div>
+        <p className="text-xs text-gray-400 dark:text-gray-500 leading-relaxed">
+          Submit your answer to see AI feedback here. Each response is evaluated on accuracy,
+          clarity, and depth.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl p-5 space-y-4">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">
+          Q{questionNumber} Feedback
+        </h3>
+        <div className="flex items-baseline gap-1">
+          <span className="text-2xl font-bold" style={{ color: '#3948CF' }}>
+            {feedback.score}
+          </span>
+          <span className="text-xs text-gray-400 dark:text-gray-500">/10</span>
+        </div>
+      </div>
+
+      {/* Score bar */}
+      <div className="h-1.5 bg-gray-100 dark:bg-gray-700 rounded-full overflow-hidden">
+        <div
+          className="h-full rounded-full transition-all duration-500"
+          style={{ width: `${feedback.score * 10}%`, backgroundColor: '#3948CF' }}
+        />
+      </div>
+
+      {/* Rating badges */}
+      <div className="space-y-2 pt-0.5">
+        <RatingBadge label="Accuracy" value={feedback.accuracy} />
+        <RatingBadge label="Clarity" value={feedback.clarity} />
+      </div>
+
+      <hr className="border-gray-100 dark:border-gray-700" />
+
+      {/* Strengths */}
+      <div>
+        <div className="flex items-center gap-1.5 mb-2">
+          <CheckCircle className="w-3.5 h-3.5 text-green-500 shrink-0" />
+          <span className="text-xs font-semibold text-gray-700 dark:text-gray-300">
+            Strengths
+          </span>
+        </div>
+        <ul className="space-y-1.5">
+          {feedback.strengths.map((s, i) => (
+            <li key={i} className="flex items-start gap-1.5 text-xs text-gray-600 dark:text-gray-400">
+              <span className="mt-1 w-1 h-1 rounded-full bg-green-400 shrink-0" />
+              {s}
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      {/* Improvements */}
+      <div>
+        <div className="flex items-center gap-1.5 mb-2">
+          <TrendingUp className="w-3.5 h-3.5 text-amber-500 shrink-0" />
+          <span className="text-xs font-semibold text-gray-700 dark:text-gray-300">
+            Improvements
+          </span>
+        </div>
+        <ul className="space-y-1.5">
+          {feedback.improvements.map((s, i) => (
+            <li key={i} className="flex items-start gap-1.5 text-xs text-gray-600 dark:text-gray-400">
+              <span className="mt-1 w-1 h-1 rounded-full bg-amber-400 shrink-0" />
+              {s}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/lib/interview/mockData.ts
+++ b/frontend/app/lib/interview/mockData.ts
@@ -1,0 +1,574 @@
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export type InterviewType = 'Technical' | 'Behavioral' | 'Mixed';
+export type Difficulty = 'Easy' | 'Medium' | 'Hard';
+export type QuestionCount = 5 | 10 | 15;
+export type RatingLevel = 'High' | 'Medium' | 'Low';
+
+export interface InterviewConfig {
+  role: string;
+  type: InterviewType;
+  count: QuestionCount;
+  difficulty: Difficulty;
+}
+
+export interface AnswerFeedback {
+  score: number; // 1–10
+  accuracy: RatingLevel;
+  clarity: RatingLevel;
+  strengths: string[];
+  improvements: string[];
+}
+
+export interface MockQuestion {
+  id: number;
+  question: string;
+  feedback: AnswerFeedback;
+}
+
+export interface SessionResult extends MockQuestion {
+  userAnswer: string;
+}
+
+export interface MockResults {
+  overallScore: number; // 0–100
+  summary: string;
+  topStrengths: string[];
+  areasToImprove: string[];
+  recommendation: string;
+  questions: SessionResult[];
+}
+
+// ─── Technical questions pool ─────────────────────────────────────────────────
+
+const TECHNICAL_QUESTIONS: MockQuestion[] = [
+  {
+    id: 1,
+    question:
+      'Can you walk me through how you would design a REST API for a social media platform? Focus on endpoint structure, authentication, and scalability considerations.',
+    feedback: {
+      score: 8,
+      accuracy: 'High',
+      clarity: 'High',
+      strengths: [
+        'Clearly outlined resource-based endpoints (/users, /posts, /comments)',
+        'Mentioned JWT for stateless authentication',
+        'Addressed pagination for list endpoints',
+      ],
+      improvements: [
+        'Rate limiting and API versioning were not mentioned',
+        'Caching strategies (Redis, CDN) were skipped',
+      ],
+    },
+  },
+  {
+    id: 2,
+    question:
+      'What is the difference between == and === in JavaScript? When would you choose one over the other?',
+    feedback: {
+      score: 9,
+      accuracy: 'High',
+      clarity: 'High',
+      strengths: [
+        'Accurately explained type coercion with ==',
+        'Gave concrete examples (0 == false, null == undefined)',
+        'Correctly recommended === as the default',
+      ],
+      improvements: ['Could mention edge cases like NaN !== NaN'],
+    },
+  },
+  {
+    id: 3,
+    question:
+      'Explain Big O notation and analyze the time complexity of binary search. Why does it matter in practice?',
+    feedback: {
+      score: 7,
+      accuracy: 'High',
+      clarity: 'Medium',
+      strengths: [
+        'Correctly identified O(log n) for binary search',
+        'Explained the divide-and-conquer approach well',
+      ],
+      improvements: [
+        'The O(1) vs O(n) contrast examples were unclear',
+        'Space complexity (O(1) iterative vs O(log n) recursive) was omitted',
+        'Real-world context for when Big O matters could be stronger',
+      ],
+    },
+  },
+  {
+    id: 4,
+    question:
+      'How would you approach debugging a memory leak in a production Node.js application?',
+    feedback: {
+      score: 7,
+      accuracy: 'Medium',
+      clarity: 'High',
+      strengths: [
+        'Suggested using --inspect with Chrome DevTools',
+        'Mentioned heap snapshots as a diagnostic tool',
+        'Proposed checking event listener cleanup',
+      ],
+      improvements: [
+        'process.memoryUsage() for quick monitoring was not mentioned',
+        'Could discuss clinic.js or 0x as profiling tools',
+        'Circular references as a leak source were not covered',
+      ],
+    },
+  },
+  {
+    id: 5,
+    question:
+      'What are the SOLID principles? Explain the Single Responsibility Principle with a concrete code example.',
+    feedback: {
+      score: 8,
+      accuracy: 'High',
+      clarity: 'High',
+      strengths: [
+        'Listed all five SOLID principles correctly',
+        'Code example clearly demonstrated SRP',
+        'Connected SRP to testability and maintainability',
+      ],
+      improvements: [
+        'Examples for the other four principles were not discussed',
+        'Could explain how violating SRP leads to "God classes"',
+      ],
+    },
+  },
+  {
+    id: 6,
+    question:
+      'Describe your experience with relational databases. How would you optimize a slow SQL query?',
+    feedback: {
+      score: 6,
+      accuracy: 'Medium',
+      clarity: 'Medium',
+      strengths: [
+        'Mentioned using EXPLAIN to analyze query plans',
+        'Suggested adding indexes on frequently queried columns',
+      ],
+      improvements: [
+        'Query caching and connection pooling were not mentioned',
+        'Covering/composite indexes were not discussed',
+        'Should mention avoiding SELECT * and reducing N+1 queries',
+        'No mention of normalization trade-offs',
+      ],
+    },
+  },
+  {
+    id: 7,
+    question:
+      'What is the difference between a process and a thread? How does Node.js handle concurrency despite being single-threaded?',
+    feedback: {
+      score: 8,
+      accuracy: 'High',
+      clarity: 'High',
+      strengths: [
+        'Correctly explained shared memory in threads vs isolated memory in processes',
+        'Explained the event loop and non-blocking I/O well',
+        'Mentioned the worker_threads module for CPU-intensive tasks',
+      ],
+      improvements: [
+        'The cluster module for multi-process Node.js was skipped',
+        'libuv thread pool internals were not touched on',
+      ],
+    },
+  },
+  {
+    id: 8,
+    question:
+      'How would you implement authentication and authorization in a web application? Describe your approach end-to-end.',
+    feedback: {
+      score: 9,
+      accuracy: 'High',
+      clarity: 'High',
+      strengths: [
+        'Described JWT structure (header, payload, signature) accurately',
+        'Mentioned refresh token rotation for security',
+        'Differentiated authentication from authorization clearly',
+        'Mentioned RBAC for authorization',
+      ],
+      improvements: ['OAuth 2.0 / OIDC for third-party auth was briefly skipped'],
+    },
+  },
+  {
+    id: 9,
+    question:
+      'Explain the concept of microservices. What are the trade-offs compared to a monolithic architecture?',
+    feedback: {
+      score: 7,
+      accuracy: 'High',
+      clarity: 'Medium',
+      strengths: [
+        'Identified independent deployability as a key microservices benefit',
+        'Mentioned service communication patterns (REST, message queues)',
+        'Acknowledged increased operational complexity',
+      ],
+      improvements: [
+        'Distributed tracing and observability challenges were omitted',
+        'Data consistency across services (sagas, 2PC) was not discussed',
+        'Could mention when a monolith is actually the better choice',
+      ],
+    },
+  },
+  {
+    id: 10,
+    question:
+      'Tell me about a challenging technical problem you solved recently. Walk me through your thought process and what you learned.',
+    feedback: {
+      score: 8,
+      accuracy: 'High',
+      clarity: 'High',
+      strengths: [
+        'Used STAR format (Situation, Task, Action, Result) effectively',
+        'Demonstrated structured problem-solving under pressure',
+        'Clearly articulated lessons learned',
+      ],
+      improvements: [
+        'Could quantify impact more specifically (e.g., "reduced latency by 40%")',
+        'Team collaboration details could be elaborated',
+      ],
+    },
+  },
+];
+
+// ─── Behavioral questions pool ────────────────────────────────────────────────
+
+const BEHAVIORAL_QUESTIONS: MockQuestion[] = [
+  {
+    id: 1,
+    question:
+      'Tell me about a time you had to work with a difficult team member. How did you handle the situation?',
+    feedback: {
+      score: 8,
+      accuracy: 'High',
+      clarity: 'High',
+      strengths: [
+        'Stayed professional and focused on the work outcome',
+        'Proactively sought a 1-on-1 conversation to resolve the conflict',
+        'Demonstrated empathy by listening to the other person\'s concerns',
+      ],
+      improvements: [
+        'Could describe how you followed up after the resolution',
+        'Mention what you would do differently in hindsight',
+      ],
+    },
+  },
+  {
+    id: 2,
+    question:
+      'Describe a situation where you had to meet a tight deadline. What did you do to ensure delivery?',
+    feedback: {
+      score: 9,
+      accuracy: 'High',
+      clarity: 'High',
+      strengths: [
+        'Broke the work into prioritized tasks immediately',
+        'Communicated proactively with stakeholders about scope',
+        'Delivered on time without sacrificing quality on critical parts',
+      ],
+      improvements: [
+        'Could mention how you prevented similar situations in the future',
+      ],
+    },
+  },
+  {
+    id: 3,
+    question:
+      'Give me an example of when you had to learn something quickly under pressure. How did you approach it?',
+    feedback: {
+      score: 7,
+      accuracy: 'High',
+      clarity: 'Medium',
+      strengths: [
+        'Showed resourcefulness by using documentation and asking mentors',
+        'Demonstrated a clear growth mindset',
+      ],
+      improvements: [
+        'The example could be more specific about what was learned',
+        'Outcome and measurable impact were not clearly stated',
+      ],
+    },
+  },
+  {
+    id: 4,
+    question:
+      'Tell me about a time you received critical feedback. How did you respond to it?',
+    feedback: {
+      score: 8,
+      accuracy: 'High',
+      clarity: 'High',
+      strengths: [
+        'Accepted the feedback without becoming defensive',
+        'Created an action plan and followed through',
+        'Showed maturity in using it as a growth opportunity',
+      ],
+      improvements: [
+        'Could mention seeking clarification to ensure full understanding',
+      ],
+    },
+  },
+  {
+    id: 5,
+    question:
+      'Describe a time you had to make a difficult decision with incomplete information. What was your process?',
+    feedback: {
+      score: 7,
+      accuracy: 'Medium',
+      clarity: 'High',
+      strengths: [
+        'Gathered as much available information as quickly as possible',
+        'Consulted relevant stakeholders before deciding',
+        'Made the call decisively when needed',
+      ],
+      improvements: [
+        'Risk assessment and mitigation before deciding was not explained',
+        'Retrospective analysis after the outcome was not mentioned',
+      ],
+    },
+  },
+  {
+    id: 6,
+    question:
+      'Tell me about a project you are most proud of. What was your specific contribution?',
+    feedback: {
+      score: 9,
+      accuracy: 'High',
+      clarity: 'High',
+      strengths: [
+        'Clearly articulated ownership and individual impact',
+        'Described the business value of the project',
+        'Showed genuine enthusiasm and investment in the work',
+      ],
+      improvements: [
+        'Could mention what the team learned collectively from the project',
+      ],
+    },
+  },
+  {
+    id: 7,
+    question:
+      'Describe a time you had to persuade someone to see things your way. How did you approach it?',
+    feedback: {
+      score: 7,
+      accuracy: 'High',
+      clarity: 'Medium',
+      strengths: [
+        'Used data and evidence to support the argument',
+        'Listened actively to objections and addressed them',
+      ],
+      improvements: [
+        'Could describe how you adapted your communication style to the audience',
+        'The relationship status after the conversation was unclear',
+      ],
+    },
+  },
+  {
+    id: 8,
+    question:
+      'Give an example of when you took initiative beyond your assigned responsibilities.',
+    feedback: {
+      score: 8,
+      accuracy: 'High',
+      clarity: 'High',
+      strengths: [
+        'Identified a problem proactively without being asked',
+        'Drove the solution end-to-end with clear ownership',
+        'Outcome had a measurable positive impact on the team',
+      ],
+      improvements: [
+        'Could mention how you got buy-in from leadership or peers',
+      ],
+    },
+  },
+  {
+    id: 9,
+    question:
+      'Tell me about a time a project did not go as planned. What happened and what did you do?',
+    feedback: {
+      score: 7,
+      accuracy: 'High',
+      clarity: 'Medium',
+      strengths: [
+        'Took accountability without placing blame on others',
+        'Pivoted quickly and communicated the issue to stakeholders',
+      ],
+      improvements: [
+        'Root cause analysis could be more detailed',
+        'Preventive measures taken afterwards were not mentioned',
+      ],
+    },
+  },
+  {
+    id: 10,
+    question:
+      'Where do you see yourself in five years, and how does this role fit into that vision?',
+    feedback: {
+      score: 8,
+      accuracy: 'High',
+      clarity: 'High',
+      strengths: [
+        'Career vision was realistic and well-articulated',
+        'Clearly connected long-term goals to this role',
+        'Showed genuine interest in growth opportunities',
+      ],
+      improvements: [
+        'Could mention specific skills you plan to develop in this role',
+      ],
+    },
+  },
+];
+
+// ─── Mixed pool (interleaved) ──────────────────────────────────────────────────
+
+const MIXED_QUESTIONS: MockQuestion[] = [
+  TECHNICAL_QUESTIONS[0],
+  BEHAVIORAL_QUESTIONS[0],
+  TECHNICAL_QUESTIONS[1],
+  BEHAVIORAL_QUESTIONS[1],
+  TECHNICAL_QUESTIONS[2],
+  BEHAVIORAL_QUESTIONS[2],
+  TECHNICAL_QUESTIONS[3],
+  BEHAVIORAL_QUESTIONS[3],
+  TECHNICAL_QUESTIONS[4],
+  BEHAVIORAL_QUESTIONS[4],
+  TECHNICAL_QUESTIONS[5],
+  BEHAVIORAL_QUESTIONS[5],
+  TECHNICAL_QUESTIONS[6],
+  BEHAVIORAL_QUESTIONS[6],
+  TECHNICAL_QUESTIONS[7],
+].map((q, i) => ({ ...q, id: i + 1 }));
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+export function getMockQuestions(type: InterviewType, count: QuestionCount): MockQuestion[] {
+  const pool =
+    type === 'Technical'
+      ? TECHNICAL_QUESTIONS
+      : type === 'Behavioral'
+      ? BEHAVIORAL_QUESTIONS
+      : MIXED_QUESTIONS;
+
+  return pool.slice(0, Math.min(count, pool.length)).map((q, i) => ({ ...q, id: i + 1 }));
+}
+
+// ─── Hardcoded demo results (used when navigating directly to /results) ───────
+
+export const DEMO_RESULTS: MockResults = {
+  overallScore: 78,
+  summary:
+    'You demonstrated solid technical knowledge across core software engineering topics, with particularly strong answers on JavaScript fundamentals and system design. Your responses were well-structured and showed clear communication skills. The main areas for growth are database optimisation and distributed systems design.',
+  topStrengths: [
+    'Strong JavaScript and Node.js fundamentals',
+    'Clear communication with structured, well-organised answers',
+    'Good understanding of authentication and security principles',
+    'Demonstrated ownership and accountability in behavioural responses',
+  ],
+  areasToImprove: [
+    'Database optimisation and advanced SQL query techniques',
+    'Distributed systems concepts (eventual consistency, sagas)',
+    'Quantifying the impact of your work with specific metrics',
+    'Deeper knowledge of observability and monitoring tools',
+  ],
+  recommendation: 'Ready for mid-level engineering interviews',
+  questions: [
+    {
+      id: 1,
+      question:
+        'Can you walk me through how you would design a REST API for a social media platform?',
+      userAnswer:
+        'I would start by identifying the core resources: users, posts, comments, and likes. Each would have standard CRUD endpoints following REST conventions. For authentication I\'d use JWT tokens with refresh token rotation to keep sessions stateless and secure.',
+      feedback: {
+        score: 8,
+        accuracy: 'High',
+        clarity: 'High',
+        strengths: [
+          'Clearly outlined resource-based endpoints',
+          'Mentioned JWT for stateless authentication',
+          'Addressed pagination for list endpoints',
+        ],
+        improvements: [
+          'Could have mentioned rate limiting and API versioning',
+          'Caching strategies were not discussed',
+        ],
+      },
+    },
+    {
+      id: 2,
+      question: 'What is the difference between == and === in JavaScript?',
+      userAnswer:
+        'The == operator performs type coercion before comparison, while === is a strict equality check requiring both the value and type to match. I always recommend === as the default to avoid unexpected coercion bugs.',
+      feedback: {
+        score: 9,
+        accuracy: 'High',
+        clarity: 'High',
+        strengths: [
+          'Accurately explained type coercion',
+          'Gave concrete examples',
+          'Correctly recommended === as the default',
+        ],
+        improvements: ['Could mention edge cases like NaN !== NaN'],
+      },
+    },
+    {
+      id: 3,
+      question:
+        'Explain Big O notation and analyze the time complexity of binary search.',
+      userAnswer:
+        'Big O describes the upper bound on algorithm time complexity. Binary search is O(log n) because it eliminates half the search space with each comparison, making it far more efficient than linear search on sorted data.',
+      feedback: {
+        score: 7,
+        accuracy: 'High',
+        clarity: 'Medium',
+        strengths: [
+          'Correctly identified O(log n) for binary search',
+          'Explained the divide-and-conquer approach well',
+        ],
+        improvements: [
+          'The O(1) vs O(n) contrast could be clearer',
+          'Space complexity was omitted',
+        ],
+      },
+    },
+    {
+      id: 4,
+      question:
+        'How would you approach debugging a memory leak in a production Node.js application?',
+      userAnswer:
+        'I would use --inspect to connect Chrome DevTools and take heap snapshots at intervals to identify objects not being garbage collected. I\'d also check for event listeners that aren\'t cleaned up.',
+      feedback: {
+        score: 7,
+        accuracy: 'Medium',
+        clarity: 'High',
+        strengths: [
+          'Suggested using --inspect with Chrome DevTools',
+          'Mentioned heap snapshots as a diagnostic tool',
+        ],
+        improvements: [
+          'process.memoryUsage() for quick monitoring was not mentioned',
+          'Could discuss clinic.js as a profiling tool',
+        ],
+      },
+    },
+    {
+      id: 5,
+      question:
+        'What are the SOLID principles? Explain the Single Responsibility Principle with a concrete example.',
+      userAnswer:
+        'SOLID stands for Single Responsibility, Open/Closed, Liskov Substitution, Interface Segregation, and Dependency Inversion. SRP means a class should have only one reason to change. For example, separating email sending logic from user registration logic into distinct classes.',
+      feedback: {
+        score: 8,
+        accuracy: 'High',
+        clarity: 'High',
+        strengths: [
+          'Listed all five SOLID principles correctly',
+          'Code example clearly demonstrated SRP',
+          'Connected SRP to testability',
+        ],
+        improvements: [
+          'Examples for the other four principles were not discussed',
+        ],
+      },
+    },
+  ],
+};


### PR DESCRIPTION
## Summary

- **Interview Setup Form** (`/interview`) — Job Role input, Interview Type dropdown (Technical / Behavioral / Mixed), Number of Questions (5 / 10 / 15), segmented Difficulty control (Easy / Medium / Hard), full validation before submission
- **Chat Session** (`/interview/session`) — AI intro message, "Start Interview" trigger, per-question chat bubbles (AI left / user right), answer textarea with Ctrl+Enter shortcut, live feedback panel sidebar (score, accuracy, clarity, strengths, improvements), animated progress dots, and end-of-session flow to results
- **Results Page** (`/interview/results`) — Circular overall score, recommendation badge, summary paragraph, top strengths, areas to improve, and an accordion per-question breakdown with user answer replay and per-answer feedback detail
- **Simulation layer** (`lib/interview/mockData.ts`) — 10 Technical + 10 Behavioral questions with realistic feedback; Mixed pool interleaves both; `DEMO_RESULTS` fallback for direct navigation; `getMockQuestions()` scoped by type + count
- **Reusable components** — `FeedbackPanel` and `CircularScore` in `components/interview/`
- **Dashboard** — Mock Interview card enabled and linked to `/interview` (was "Coming soon")
- **Sidebar nav** — Active state uses `startsWith` so `/interview/session` and `/interview/results` both highlight the Mock Interview nav item

## Architecture notes

This is a **dual-mode** implementation. The mock simulation in `mockData.ts` is intentionally preserved for the deployed demo version. Real AI API integration (backend route + session-page toggle) will be built in the next phase for the local Electron build.

## Test plan

- [ ] Navigate to `/interview` from Dashboard card and sidebar
- [ ] Submit setup form without Job Role — validation error shown
- [ ] Complete a full 5-question session end-to-end; feedback panel updates after each submit
- [ ] Progress dots fill correctly as questions are answered
- [ ] Ctrl+Enter submits answer from textarea
- [ ] "Finish Interview" → "View Results" navigates with real session data
- [ ] Navigate directly to `/interview/results` — falls back to demo data gracefully
- [ ] "Try Again" → `/interview`; "Dashboard" → `/dashboard`
- [ ] Dark mode renders correctly on all three screens
- [ ] Sidebar "Mock Interview" stays highlighted on all three sub-routes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
