### PR TITLE
feat: wire Mock Interview frontend to live backend API with dual-mode…

### DIFF
--- a/backend/src/controllers/interview.controller.ts
+++ b/backend/src/controllers/interview.controller.ts
@@ -1,0 +1,352 @@
+import { Request, Response } from 'express';
+import { randomUUID } from 'crypto';
+import Groq from 'groq-sdk';
+
+const MODEL = 'meta-llama/llama-4-scout-17b-16e-instruct';
+
+// ─── Shared helpers ───────────────────────────────────────────────────────────
+
+/** Strip markdown code fences the model sometimes wraps JSON in. */
+function stripMarkdown(content: string): string {
+  return content.replace(/```json|```/g, '').trim();
+}
+
+/** Parse AI output, stripping fences first. Throws SyntaxError on bad JSON. */
+function parseAI(content: string): unknown {
+  return JSON.parse(stripMarkdown(content));
+}
+
+/**
+ * Centralised Groq error → HTTP response mapping.
+ * Must be called as the last statement in a catch block.
+ */
+function handleGroqError(err: unknown, res: Response): void {
+  if (err instanceof Groq.AuthenticationError) {
+    res.status(401).json({ error: 'Invalid Groq API key.' });
+    return;
+  }
+  if (err instanceof Groq.RateLimitError) {
+    res.status(503).json({ error: 'AI service temporarily unavailable. Please try again.' });
+    return;
+  }
+  if (err instanceof Groq.APIError) {
+    res.status(503).json({ error: 'AI service temporarily unavailable. Please try again.' });
+    return;
+  }
+  if (err instanceof SyntaxError) {
+    res.status(500).json({ error: 'Failed to parse AI response.' });
+    return;
+  }
+  console.error('Unexpected interview error:', err);
+  res.status(500).json({ error: 'An unexpected error occurred. Please try again.' });
+}
+
+/** Validate that a value is one of the three rating strings. */
+const RATINGS = ['High', 'Medium', 'Low'] as const;
+type Rating = (typeof RATINGS)[number];
+function isRating(v: unknown): v is Rating {
+  return typeof v === 'string' && (RATINGS as readonly string[]).includes(v);
+}
+
+// ─── 1. POST /api/interview/start ─────────────────────────────────────────────
+
+export const startInterview = async (req: Request, res: Response): Promise<void> => {
+  const { role, type, questionCount, difficulty, apiKey } = req.body as {
+    role?: string;
+    type?: string;
+    questionCount?: unknown;
+    difficulty?: string;
+    apiKey?: string;
+  };
+
+  if (!apiKey?.trim()) {
+    res.status(400).json({ error: 'API key is required.' });
+    return;
+  }
+
+  const missing: string[] = [];
+  if (!role?.trim()) missing.push('role');
+  if (!type?.trim()) missing.push('type');
+  if (!questionCount) missing.push('questionCount');
+  if (!difficulty?.trim()) missing.push('difficulty');
+  if (missing.length) {
+    res.status(400).json({ error: `Missing required fields: ${missing.join(', ')}` });
+    return;
+  }
+
+  const count = Number(questionCount);
+
+  const systemPrompt = `You are a professional interviewer conducting a ${difficulty}-difficulty ${type} interview for a ${role} position.
+Return ONLY a raw JSON object — no markdown, no code blocks, no extra text outside the JSON.
+The JSON must have exactly this shape:
+{
+  "introduction": "<a warm, professional 2-3 sentence introduction explaining the session context and what to expect>",
+  "questions": ["<question 1>", "<question 2>", ..., "<question ${count}>"]
+}
+
+Generate exactly ${count} interview questions appropriate for:
+- Role: ${role}
+- Type: ${type} (Technical = algorithms/system-design/coding concepts; Behavioral = situational/competency; Mixed = alternate both)
+- Difficulty: ${difficulty} (Easy = foundational; Medium = practical experience; Hard = senior/complex)
+
+Questions must be specific to the role and varied — no duplicates.`;
+
+  const userPrompt = `Generate ${count} ${difficulty} ${type} interview questions for a ${role} position. Return only the raw JSON object.`;
+
+  try {
+    const groq = new Groq({ apiKey });
+    const response = await groq.chat.completions.create({
+      model: MODEL,
+      messages: [
+        { role: 'system', content: systemPrompt },
+        { role: 'user', content: userPrompt },
+      ],
+      temperature: 0.7,
+      max_tokens: 1024,
+    });
+
+    const content = response.choices[0]?.message?.content ?? '';
+    const parsed = parseAI(content) as {
+      introduction?: unknown;
+      questions?: unknown;
+    };
+
+    if (
+      typeof parsed.introduction !== 'string' ||
+      !parsed.introduction.trim() ||
+      !Array.isArray(parsed.questions) ||
+      parsed.questions.length === 0 ||
+      !parsed.questions.every((q) => typeof q === 'string' && q.trim())
+    ) {
+      console.error('[interview/start] Invalid AI shape:', parsed);
+      res.status(500).json({ error: 'Failed to parse AI response.' });
+      return;
+    }
+
+    res.json({
+      sessionId: randomUUID(),
+      introduction: parsed.introduction.trim(),
+      questions: (parsed.questions as string[]).map((q) => q.trim()),
+    });
+  } catch (err) {
+    handleGroqError(err, res);
+  }
+};
+
+// ─── 2. POST /api/interview/answer ────────────────────────────────────────────
+
+export const evaluateAnswer = async (req: Request, res: Response): Promise<void> => {
+  const { sessionId, questionIndex, question, answer, apiKey } = req.body as {
+    sessionId?: string;
+    questionIndex?: unknown;
+    question?: string;
+    answer?: string;
+    apiKey?: string;
+  };
+
+  if (!apiKey?.trim()) {
+    res.status(400).json({ error: 'API key is required.' });
+    return;
+  }
+
+  const missing: string[] = [];
+  if (!sessionId?.trim()) missing.push('sessionId');
+  if (questionIndex === undefined || questionIndex === null) missing.push('questionIndex');
+  if (!question?.trim()) missing.push('question');
+  if (!answer?.trim()) missing.push('answer');
+  if (missing.length) {
+    res.status(400).json({ error: `Missing required fields: ${missing.join(', ')}` });
+    return;
+  }
+
+  const systemPrompt = `You are a strict but fair interview evaluator assessing a candidate's answer.
+Return ONLY a raw JSON object — no markdown, no code blocks, no extra text outside the JSON.
+The JSON must have exactly this shape:
+{
+  "accuracy": "<High | Medium | Low>",
+  "clarity": "<High | Medium | Low>",
+  "strengths": ["<strength 1>", "<strength 2>"],
+  "improvements": ["<improvement 1>", "<improvement 2>"],
+  "score": <integer 1–10>
+}
+
+Rules:
+- accuracy and clarity must be EXACTLY one of: "High", "Medium", "Low"
+- strengths: 2–3 short, specific, positive observations about the answer
+- improvements: 2–3 short, actionable suggestions for what could be better
+- score: a single integer between 1 and 10 reflecting overall answer quality`;
+
+  const userPrompt = `Interview question: ${question}\n\nCandidate's answer: ${answer}\n\nEvaluate this answer and return only the raw JSON object.`;
+
+  try {
+    const groq = new Groq({ apiKey });
+    const response = await groq.chat.completions.create({
+      model: MODEL,
+      messages: [
+        { role: 'system', content: systemPrompt },
+        { role: 'user', content: userPrompt },
+      ],
+      temperature: 0.7,
+      max_tokens: 1024,
+    });
+
+    const content = response.choices[0]?.message?.content ?? '';
+    const parsed = parseAI(content) as {
+      accuracy?: unknown;
+      clarity?: unknown;
+      strengths?: unknown;
+      improvements?: unknown;
+      score?: unknown;
+    };
+
+    if (
+      !isRating(parsed.accuracy) ||
+      !isRating(parsed.clarity) ||
+      !Array.isArray(parsed.strengths) ||
+      !Array.isArray(parsed.improvements) ||
+      typeof parsed.score !== 'number' ||
+      !Number.isInteger(parsed.score) ||
+      parsed.score < 1 ||
+      parsed.score > 10
+    ) {
+      console.error('[interview/answer] Invalid AI shape:', parsed);
+      res.status(500).json({ error: 'Failed to parse AI response.' });
+      return;
+    }
+
+    res.json({
+      accuracy: parsed.accuracy,
+      clarity: parsed.clarity,
+      strengths: (parsed.strengths as unknown[])
+        .filter((s): s is string => typeof s === 'string')
+        .slice(0, 3)
+        .map((s) => s.trim()),
+      improvements: (parsed.improvements as unknown[])
+        .filter((s): s is string => typeof s === 'string')
+        .slice(0, 3)
+        .map((s) => s.trim()),
+      score: parsed.score,
+    });
+  } catch (err) {
+    handleGroqError(err, res);
+  }
+};
+
+// ─── 3. POST /api/interview/complete ──────────────────────────────────────────
+
+export const completeInterview = async (req: Request, res: Response): Promise<void> => {
+  const { sessionId, role, answers, feedbacks, apiKey } = req.body as {
+    sessionId?: string;
+    role?: string;
+    answers?: unknown;
+    feedbacks?: unknown;
+    apiKey?: string;
+  };
+
+  if (!apiKey?.trim()) {
+    res.status(400).json({ error: 'API key is required.' });
+    return;
+  }
+
+  const missing: string[] = [];
+  if (!sessionId?.trim()) missing.push('sessionId');
+  if (!role?.trim()) missing.push('role');
+  if (!Array.isArray(answers) || answers.length === 0) missing.push('answers');
+  if (!Array.isArray(feedbacks) || feedbacks.length === 0) missing.push('feedbacks');
+  if (missing.length) {
+    res.status(400).json({ error: `Missing required fields: ${missing.join(', ')}` });
+    return;
+  }
+
+  const feedbackList = feedbacks as Array<{ score?: unknown; accuracy?: unknown; clarity?: unknown }>;
+
+  // Build a human-readable per-question summary for the prompt
+  const feedbackSummary = feedbackList
+    .map(
+      (f, i) =>
+        `Q${i + 1}: Score ${f.score ?? '?'}/10, Accuracy: ${f.accuracy ?? '?'}, Clarity: ${f.clarity ?? '?'}`,
+    )
+    .join('\n');
+
+  const avgScore =
+    feedbackList.reduce((sum, f) => sum + (typeof f.score === 'number' ? f.score : 0), 0) /
+    feedbackList.length;
+
+  const systemPrompt = `You are a senior hiring manager giving a final debrief to a candidate who just completed a ${role} interview.
+Return ONLY a raw JSON object — no markdown, no code blocks, no extra text outside the JSON.
+The JSON must have exactly this shape:
+{
+  "overallScore": <float 1.0–10.0, one decimal place>,
+  "summary": "<2-3 sentence paragraph summarising overall performance>",
+  "topStrengths": ["<strength 1>", "<strength 2>", "<strength 3>"],
+  "areasToImprove": ["<area 1>", "<area 2>", "<area 3>"],
+  "recommendation": "<single concise sentence, e.g. 'Ready for mid-level interviews'>"
+}
+
+Rules:
+- overallScore must be a float between 1.0 and 10.0
+- topStrengths and areasToImprove: 2–4 short, specific strings each
+- recommendation: one sentence only, no period-separated clauses`;
+
+  const userPrompt = `Role: ${role}
+Average per-question score: ${avgScore.toFixed(1)}/10
+
+Per-question breakdown:
+${feedbackSummary}
+
+Provide the final interview feedback as a raw JSON object only.`;
+
+  try {
+    const groq = new Groq({ apiKey });
+    const response = await groq.chat.completions.create({
+      model: MODEL,
+      messages: [
+        { role: 'system', content: systemPrompt },
+        { role: 'user', content: userPrompt },
+      ],
+      temperature: 0.7,
+      max_tokens: 1024,
+    });
+
+    const content = response.choices[0]?.message?.content ?? '';
+    const parsed = parseAI(content) as {
+      overallScore?: unknown;
+      summary?: unknown;
+      topStrengths?: unknown;
+      areasToImprove?: unknown;
+      recommendation?: unknown;
+    };
+
+    if (
+      typeof parsed.overallScore !== 'number' ||
+      typeof parsed.summary !== 'string' ||
+      !parsed.summary.trim() ||
+      !Array.isArray(parsed.topStrengths) ||
+      !Array.isArray(parsed.areasToImprove) ||
+      typeof parsed.recommendation !== 'string' ||
+      !parsed.recommendation.trim()
+    ) {
+      console.error('[interview/complete] Invalid AI shape:', parsed);
+      res.status(500).json({ error: 'Failed to parse AI response.' });
+      return;
+    }
+
+    const clamped = Math.min(10, Math.max(1, parsed.overallScore));
+
+    res.json({
+      overallScore: Math.round(clamped * 10) / 10,
+      summary: parsed.summary.trim(),
+      topStrengths: (parsed.topStrengths as unknown[])
+        .filter((s): s is string => typeof s === 'string')
+        .slice(0, 4)
+        .map((s) => s.trim()),
+      areasToImprove: (parsed.areasToImprove as unknown[])
+        .filter((s): s is string => typeof s === 'string')
+        .slice(0, 4)
+        .map((s) => s.trim()),
+      recommendation: parsed.recommendation.trim(),
+    });
+  } catch (err) {
+    handleGroqError(err, res);
+  }
+};

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -4,6 +4,7 @@ import dotenv from 'dotenv';
 import prisma from './lib/prisma';
 import jobsRouter from './routes/jobs.routes';
 import resumeRouter from './routes/resume.routes';
+import interviewRouter from './routes/interview.routes';
 
 // Load environment variables
 dotenv.config();
@@ -34,6 +35,7 @@ app.use(express.json());
 // Routes
 app.use('/api/jobs', jobsRouter);
 app.use('/api/resume', resumeRouter);
+app.use('/api/interview', interviewRouter);
 
 // Health check
 app.get('/health', async (_req, res) => {

--- a/backend/src/routes/interview.routes.ts
+++ b/backend/src/routes/interview.routes.ts
@@ -1,0 +1,14 @@
+import { Router } from 'express';
+import {
+  startInterview,
+  evaluateAnswer,
+  completeInterview,
+} from '../controllers/interview.controller';
+
+const router = Router();
+
+router.post('/start', startInterview);      // POST /api/interview/start
+router.post('/answer', evaluateAnswer);     // POST /api/interview/answer
+router.post('/complete', completeInterview); // POST /api/interview/complete
+
+export default router;

--- a/frontend/app/lib/api/interview.ts
+++ b/frontend/app/lib/api/interview.ts
@@ -1,0 +1,116 @@
+import axios from 'axios';
+
+const isElectron =
+  typeof window !== 'undefined' &&
+  navigator.userAgent.toLowerCase().includes('electron');
+
+const isDevelopment =
+  process.env.NODE_ENV === 'development' ||
+  (typeof window !== 'undefined' && window.location.hostname === 'localhost');
+
+const BASE_URL =
+  isElectron || isDevelopment
+    ? 'http://localhost:5000'
+    : 'https://prepify-7vah.onrender.com';
+
+const interviewClient = axios.create({
+  baseURL: BASE_URL,
+  headers: { 'Content-Type': 'application/json' },
+  timeout: 45000, // AI calls can take a while
+});
+
+// ─── Request / Response types ─────────────────────────────────────────────────
+
+export interface StartInterviewRequest {
+  role: string;
+  type: string;
+  questionCount: number;
+  difficulty: string;
+  apiKey: string;
+}
+
+export interface StartInterviewResponse {
+  sessionId: string;
+  introduction: string;
+  questions: string[];
+}
+
+export interface EvaluateAnswerRequest {
+  sessionId: string;
+  questionIndex: number;
+  question: string;
+  answer: string;
+  apiKey: string;
+}
+
+export interface LiveFeedback {
+  accuracy: 'High' | 'Medium' | 'Low';
+  clarity: 'High' | 'Medium' | 'Low';
+  strengths: string[];
+  improvements: string[];
+  score: number;
+}
+
+export interface CompleteInterviewRequest {
+  sessionId: string;
+  role: string;
+  answers: string[];
+  feedbacks: LiveFeedback[];
+  apiKey: string;
+}
+
+export interface CompleteInterviewResponse {
+  overallScore: number; // 1.0–10.0
+  summary: string;
+  topStrengths: string[];
+  areasToImprove: string[];
+  recommendation: string;
+}
+
+// ─── API functions ────────────────────────────────────────────────────────────
+
+export async function apiStartInterview(
+  req: StartInterviewRequest,
+): Promise<StartInterviewResponse> {
+  const res = await interviewClient.post<StartInterviewResponse>(
+    '/api/interview/start',
+    req,
+  );
+  return res.data;
+}
+
+export async function apiEvaluateAnswer(
+  req: EvaluateAnswerRequest,
+): Promise<LiveFeedback> {
+  const res = await interviewClient.post<LiveFeedback>('/api/interview/answer', req);
+  return res.data;
+}
+
+export async function apiCompleteInterview(
+  req: CompleteInterviewRequest,
+): Promise<CompleteInterviewResponse> {
+  const res = await interviewClient.post<CompleteInterviewResponse>(
+    '/api/interview/complete',
+    req,
+  );
+  return res.data;
+}
+
+// ─── Error helper (call from components) ──────────────────────────────────────
+
+export function extractInterviewError(err: unknown): string {
+  if (err && typeof err === 'object' && 'response' in err) {
+    const e = err as {
+      response?: { data?: { error?: string }; status?: number };
+      code?: string;
+    };
+    if (e.response?.data?.error) return e.response.data.error;
+    if (e.response?.status === 401)
+      return 'Invalid API key. Please check and re-enter.';
+    if (e.response?.status === 503)
+      return 'AI service temporarily unavailable. Please try again.';
+    if (e.code === 'ECONNREFUSED' || e.code === 'ERR_NETWORK')
+      return 'Cannot reach the server. Make sure the backend is running on port 5000.';
+  }
+  return 'Something went wrong. Please try again.';
+}


### PR DESCRIPTION
## Summary
- Add 3 Express endpoints (`/api/interview/start`, `/answer`, `/complete`) powered by Groq `llama-4-scout-17b-16e-instruct` — BYOK, key passed per-request
- Add typed axios client (`frontend/app/lib/api/interview.ts`) for all 3 endpoints
- Rewrite session page with auto-detected dual-mode: **Live** (Electron/localhost) hits real API; **Demo** (Vercel) runs entirely on mock data — zero API calls
- Update results page to render AI-generated summary fields when present, falling back to demo data otherwise
- Fix empty chat on live mode load — static intro message now shown in both modes

## Test plan
- [x] Run `npm run dev`, set a Groq API key, complete a full interview — questions, per-answer feedback, and final report all from the API
- [x] Open deployed Vercel URL and confirm demo simulation works with nothing in Network tab
- [x] Start interview without API key — confirm key modal appears
- [x] Verify results page shows AI summary in live mode and fallback text in demo mode
