### PR TITLE
feat: implement voice input (speech-to-text) for mock interview answers

### DIFF
--- a/frontend/app/(app)/interview/session/page.tsx
+++ b/frontend/app/(app)/interview/session/page.tsx
@@ -2,7 +2,8 @@
 
 import { useState, useRef, useEffect, Suspense } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
-import { Bot, User, PlayCircle, ChevronRight, Flag, Loader2, AlertCircle } from 'lucide-react';
+import { Bot, User, PlayCircle, ChevronRight, Flag, Loader2, AlertCircle, Mic, MicOff } from 'lucide-react';
+import { useSpeechRecognition } from '../../../hooks/useSpeechRecognition';
 import {
   getMockQuestions,
   type MockQuestion,
@@ -121,6 +122,22 @@ function SessionContent() {
 
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  // Speech-to-text hook
+  const {
+    state: speechState,
+    error: speechError,
+    startListening,
+    stopListening,
+    clearError: clearSpeechError,
+    isSupported: isSpeechSupported,
+  } = useSpeechRecognition({
+    onTranscript: (transcript) => {
+      // Append transcribed text to existing answer
+      setUserAnswer((prev) => (prev ? prev + ' ' + transcript : transcript));
+    },
+    language: 'en-US',
+  });
 
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
@@ -485,23 +502,77 @@ function SessionContent() {
 
             {phase === 'asking' && (
               <div className="space-y-3">
-                <textarea
-                  ref={textareaRef}
-                  value={userAnswer}
-                  onChange={(e) => setUserAnswer(e.target.value)}
-                  onKeyDown={(e) => {
-                    if ((e.ctrlKey || e.metaKey) && e.key === 'Enter' && userAnswer.trim()) {
-                      e.preventDefault();
-                      handleSubmitAnswer();
+                {/* Speech error banner */}
+                {speechError && (
+                  <div className="mx-0 mb-3 flex items-start gap-2 px-3 py-2.5 rounded-lg bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-800">
+                    <AlertCircle className="w-4 h-4 text-yellow-600 dark:text-yellow-500 shrink-0 mt-0.5" />
+                    <p className="text-xs text-yellow-700 dark:text-yellow-400 leading-relaxed">{speechError}</p>
+                    <button
+                      onClick={clearSpeechError}
+                      className="ml-auto text-yellow-500 hover:text-yellow-700 text-xs shrink-0"
+                    >
+                      ✕
+                    </button>
+                  </div>
+                )}
+
+                {/* Textarea with mic button embedded inside (bottom-right corner) */}
+                <div className="relative">
+                  <textarea
+                    ref={textareaRef}
+                    value={userAnswer}
+                    onChange={(e) => setUserAnswer(e.target.value)}
+                    onKeyDown={(e) => {
+                      if ((e.ctrlKey || e.metaKey) && e.key === 'Enter' && userAnswer.trim()) {
+                        e.preventDefault();
+                        handleSubmitAnswer();
+                      }
+                    }}
+                    disabled={speechState === 'listening'}
+                    rows={4}
+                    placeholder={
+                      speechState === 'listening'
+                        ? 'Listening… speak your answer'
+                        : 'Type your answer here… (Ctrl+Enter to submit)'
                     }
-                  }}
-                  rows={4}
-                  placeholder="Type your answer here… (Ctrl+Enter to submit)"
-                  className="w-full px-3 py-2.5 border border-gray-200 dark:border-gray-600 rounded-lg text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:border-[#3948CF] resize-none transition-colors"
-                />
+                    className={`w-full px-3 py-2.5 border rounded-lg text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none resize-none transition-colors disabled:cursor-not-allowed ${
+                      speechState === 'listening'
+                        ? 'border-red-400 dark:border-red-500 focus:border-red-400 pr-11'
+                        : 'border-gray-200 dark:border-gray-600 focus:border-[#3948CF] pr-11'
+                    }`}
+                  />
+
+                  {/* Mic button — sits in the bottom-right corner of the textarea */}
+                  {isSpeechSupported && (
+                    <button
+                      onClick={speechState === 'listening' ? stopListening : startListening}
+                      disabled={speechState === 'processing'}
+                      title={speechState === 'listening' ? 'Stop recording' : 'Speak your answer'}
+                      className={`absolute bottom-2.5 right-2.5 w-7 h-7 rounded-md border-2 flex items-center justify-center transition-all disabled:opacity-40 disabled:cursor-not-allowed ${
+                        speechState === 'listening'
+                          ? 'bg-red-500/10 dark:bg-red-500/25 border-red-400 dark:border-red-400'
+                          : 'bg-indigo-600/10 dark:bg-indigo-500/30 border-indigo-600 dark:border-indigo-400'
+                      }`}
+                    >
+                      {speechState === 'listening' ? (
+                        <MicOff className="w-3.5 h-3.5 text-red-500 dark:text-red-400 animate-pulse" />
+                      ) : (
+                        <Mic className="w-3.5 h-3.5 text-indigo-600 dark:text-indigo-400" />
+                      )}
+                    </button>
+                  )}
+                </div>
+
+                {/* Subtle recording indicator below the textarea */}
+                {speechState === 'listening' && (
+                  <p className="text-xs text-red-500 dark:text-red-400">
+                    Recording — click the mic to stop
+                  </p>
+                )}
+
                 <button
                   onClick={handleSubmitAnswer}
-                  disabled={!userAnswer.trim()}
+                  disabled={!userAnswer.trim() || speechState === 'processing'}
                   className="px-5 py-2.5 rounded-xl text-white text-sm font-semibold transition-opacity hover:opacity-90 disabled:opacity-40 disabled:cursor-not-allowed"
                   style={{ backgroundColor: '#3948CF' }}
                 >

--- a/frontend/app/hooks/useSpeechRecognition.ts
+++ b/frontend/app/hooks/useSpeechRecognition.ts
@@ -1,0 +1,209 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+// ─── Minimal Web Speech API types ─────────────────────────────────────────────
+// Defined locally because the project's TS config does not include the full
+// Speech Recognition DOM lib. These match the actual browser API shape.
+
+interface SpeechAlternative {
+  readonly transcript: string;
+}
+
+interface SpeechResult {
+  readonly isFinal: boolean;
+  readonly length: number;
+  [index: number]: SpeechAlternative;
+}
+
+interface SpeechResultList {
+  readonly length: number;
+  [index: number]: SpeechResult;
+}
+
+interface SpeechResultEvent {
+  readonly resultIndex: number;
+  readonly results: SpeechResultList;
+}
+
+interface SpeechErrorEvent {
+  readonly error: string;
+}
+
+interface Recognizer {
+  continuous: boolean;
+  interimResults: boolean;
+  lang: string;
+  start(): void;
+  stop(): void;
+  abort(): void;
+  onresult: ((event: SpeechResultEvent) => void) | null;
+  onerror: ((event: SpeechErrorEvent) => void) | null;
+  onend: (() => void) | null;
+}
+
+interface RecognizerConstructor {
+  new (): Recognizer;
+}
+
+// Extend Window so we can read both the standard and webkit-prefixed APIs
+// without falling back to `any`.
+declare global {
+  interface Window {
+    SpeechRecognition?: RecognizerConstructor;
+    webkitSpeechRecognition?: RecognizerConstructor;
+  }
+}
+
+// ─── Hook ─────────────────────────────────────────────────────────────────────
+
+export type SpeechRecognitionState = 'idle' | 'listening' | 'processing' | 'error';
+
+interface UseSpeechRecognitionOptions {
+  onTranscript: (text: string) => void;
+  language?: string;
+}
+
+interface UseSpeechRecognitionReturn {
+  state: SpeechRecognitionState;
+  transcript: string;
+  error: string | null;
+  startListening: () => void;
+  stopListening: () => void;
+  clearError: () => void;
+  isSupported: boolean;
+}
+
+/**
+ * Hook for Web Speech API based speech-to-text.
+ * Uses window.SpeechRecognition (standard) or window.webkitSpeechRecognition (WebKit).
+ * Frontend-only — no external API calls required.
+ */
+export function useSpeechRecognition({
+  onTranscript,
+  language = 'en-US',
+}: UseSpeechRecognitionOptions): UseSpeechRecognitionReturn {
+  const [state, setState] = useState<SpeechRecognitionState>('idle');
+  const [transcript, setTranscript] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  const recognizerRef = useRef<Recognizer | null>(null);
+  const isStartingRef = useRef(false);
+
+  // Store onTranscript in a ref so it is always current without being a
+  // useEffect dependency. An inline callback in the parent would otherwise
+  // cause the recognizer to be aborted and recreated on every render.
+  const onTranscriptRef = useRef(onTranscript);
+  useEffect(() => {
+    onTranscriptRef.current = onTranscript;
+  });
+
+  // isSupported is a one-time browser feature check — stable for the page lifetime.
+  const isSupported = useMemo(
+    () =>
+      typeof window !== 'undefined' &&
+      !!(window.SpeechRecognition ?? window.webkitSpeechRecognition),
+    [],
+  );
+
+  // Create the recognizer once on mount (or when language changes).
+  //
+  // IMPORTANT: Do NOT add `state` or `onTranscript` to this dependency array.
+  // Including `state` would re-run the cleanup on every setState call, which
+  // calls recognizer.abort() and kills the active recognition session immediately.
+  useEffect(() => {
+    const API = window.SpeechRecognition ?? window.webkitSpeechRecognition;
+    if (!API) return;
+
+    const recognizer = new API();
+    recognizer.continuous = false;    // Auto-stops after a pause in speech
+    recognizer.interimResults = true; // Stream partial results while speaking
+    recognizer.lang = language;
+
+    // Build up the final transcript from successive result events.
+    recognizer.onresult = (event: SpeechResultEvent) => {
+      for (let i = event.resultIndex; i < event.results.length; i++) {
+        const segment = event.results[i][0].transcript;
+        if (event.results[i].isFinal) {
+          setTranscript((prev) => prev + segment);
+          onTranscriptRef.current(segment);
+        }
+      }
+    };
+
+    recognizer.onerror = (event: SpeechErrorEvent) => {
+      // 'aborted' fires when stop() is called manually — it is not a real error.
+      // onend fires immediately after and handles the transition back to idle.
+      if (event.error === 'aborted') return;
+      setState('error');
+      setError(getErrorMessage(event.error));
+    };
+
+    // When recognition ends (naturally or via stop()), return to idle.
+    // Use a functional update to avoid capturing a stale `state` value in closure.
+    recognizer.onend = () => {
+      setState((prev) => (prev === 'listening' ? 'idle' : prev));
+    };
+
+    recognizerRef.current = recognizer;
+
+    return () => {
+      recognizer.abort();
+      recognizerRef.current = null;
+    };
+  }, [language]);
+
+  const startListening = useCallback(() => {
+    if (!recognizerRef.current) {
+      setError('Speech recognition is not supported in this browser.');
+      setState('error');
+      return;
+    }
+
+    // Prevent rapid double-starts (e.g. fast double-click on the mic button).
+    if (isStartingRef.current) return;
+    isStartingRef.current = true;
+
+    setTranscript('');
+    setError(null);
+    setState('listening');
+
+    try {
+      recognizerRef.current.start();
+    } catch {
+      // The recognizer may already be running — treat as still listening.
+    } finally {
+      isStartingRef.current = false;
+    }
+  }, []);
+
+  const stopListening = useCallback(() => {
+    if (!recognizerRef.current) return;
+    setState('idle');
+    recognizerRef.current.stop();
+  }, []);
+
+  // Use a functional update so clearError does not need `state` as a dependency.
+  const clearError = useCallback(() => {
+    setError(null);
+    setState((prev) => (prev === 'error' ? 'idle' : prev));
+  }, []);
+
+  return { state, transcript, error, startListening, stopListening, clearError, isSupported };
+}
+
+/**
+ * Map Web Speech API error codes to user-friendly messages.
+ * Exported for use in unit tests.
+ */
+export function getErrorMessage(errorCode: string): string {
+  const messages: Record<string, string> = {
+    'no-speech': 'No speech detected. Please try again.',
+    'audio-capture': 'Microphone not available. Check your permissions and try again.',
+    'network': 'Network error. Please check your connection.',
+    'permission-denied': 'Microphone permission denied. Allow access in your browser settings.',
+    'not-allowed': 'Microphone access not allowed. Check your browser permissions.',
+    'service-not-allowed': 'Speech recognition service is not allowed.',
+    'bad-grammar': 'Speech recognition error. Please try again.',
+    'aborted': 'Speech recognition was cancelled.',
+  };
+  return messages[errorCode] ?? `Speech recognition error: ${errorCode}`;
+}


### PR DESCRIPTION
- Add useSpeechRecognition hook using the browser Web Speech API (window.SpeechRecognition / webkitSpeechRecognition) — no paid API
- Fix critical bug: removed `state` from useEffect deps, which was causing recognizer.abort() to fire on every setState call, making mic input completely non-functional
- Handle `aborted` error silently (fires on manual stop, not a real error)
- Store onTranscript in a ref to prevent recognizer recreation on every parent re-render
- Use functional setState in onend/clearError to avoid stale closures
- Define local SpeechRecognition interfaces (project TS config lacks DOM speech types) — eliminates all `any` usage
- Embed mic button inside the textarea (absolutely positioned, bottom-right) with brand colour in light mode and high-contrast indigo-400 in dark mode
- Textarea border turns red and placeholder changes to "Listening…" while recording; subtle "Recording — click the mic to stop" indicator appears below

