### PR TITLE
feat: add demo mode indicators, responsive kanban, and UX polish

### DIFF
--- a/frontend/app/(app)/interview/page.tsx
+++ b/frontend/app/(app)/interview/page.tsx
@@ -2,8 +2,20 @@
 
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { MessageCircle, ChevronDown } from 'lucide-react';
+import { ChevronDown } from 'lucide-react';
 import type { InterviewType, Difficulty, QuestionCount } from '../../lib/interview/mockData';
+import Modal from '../../components/ui/Modal';
+
+function getIsLive(): boolean {
+  if (typeof window === 'undefined') return true;
+  return (
+    process.env.NODE_ENV === 'development' ||
+    window.location.hostname === 'localhost' ||
+    window.location.hostname === '127.0.0.1'
+  );
+}
+
+const isLive = getIsLive();
 
 interface FormState {
   role: string;
@@ -18,6 +30,7 @@ interface FormErrors {
 
 export default function InterviewSetupPage() {
   const router = useRouter();
+  const [showDemoModal, setShowDemoModal] = useState(!isLive);
 
   const [form, setForm] = useState<FormState>({
     role: '',
@@ -53,14 +66,15 @@ export default function InterviewSetupPage() {
   return (
     <div className="max-w-lg mx-auto">
       {/* Page header */}
-      <div className="mb-8">
-        <div
-          className="w-10 h-10 rounded-lg flex items-center justify-center mb-4"
-          style={{ backgroundColor: '#EEF0FD' }}
-        >
-          <MessageCircle className="w-5 h-5" style={{ color: '#3948CF' }} />
+      <div className="mb-8 mt-10">
+        <div className="flex items-center gap-2.5">
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-50">Mock Interview</h1>
+          {!isLive && (
+            <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-[#EEF0FD] text-[#3948CF] dark:bg-indigo-900/30 dark:text-indigo-400">
+              Demo
+            </span>
+          )}
         </div>
-        <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-50">Mock Interview</h1>
         <p className="text-gray-500 dark:text-gray-400 text-sm mt-1">
           Configure your AI-powered interview session and receive personalised feedback.
         </p>
@@ -174,6 +188,29 @@ export default function InterviewSetupPage() {
           </button>
         </form>
       </div>
+      <Modal
+        open={showDemoModal}
+        onClose={() => setShowDemoModal(false)}
+        title="You're viewing a demo"
+      >
+        <div className="flex flex-col items-center text-center gap-4 py-1">
+          <img src="/logo-light.png" alt="Prepify" className="h-6 w-auto dark:hidden" />
+          <img src="/logo-dark.png" alt="Prepify" className="h-6 w-auto hidden dark:block" />
+          <p className="text-sm text-gray-600 dark:text-gray-300 leading-relaxed">
+            The <span className="font-semibold">Mock Interview</span> is running in demo mode.
+            Questions and AI feedback are pre-built examples, not generated live. In the full
+            version, questions are tailored to your role and difficulty, and feedback is
+            powered by a real AI model.
+          </p>
+          <button
+            onClick={() => setShowDemoModal(false)}
+            className="w-full py-2.5 rounded-lg text-sm font-medium text-white transition-opacity hover:opacity-90"
+            style={{ backgroundColor: '#3948CF' }}
+          >
+            Got it, explore the demo
+          </button>
+        </div>
+      </Modal>
     </div>
   );
 }

--- a/frontend/app/(app)/interview/session/page.tsx
+++ b/frontend/app/(app)/interview/session/page.tsx
@@ -36,11 +36,10 @@ interface ChatMessage {
 
 function getIsLive(): boolean {
   if (typeof window === 'undefined') return false;
-  const isElectron = navigator.userAgent.toLowerCase().includes('electron');
-  const isDev =
+  return (
     process.env.NODE_ENV === 'development' ||
-    window.location.hostname === 'localhost';
-  return isElectron || isDev;
+    window.location.hostname === 'localhost'
+  );
 }
 
 function getStoredApiKey(): string | null {
@@ -78,7 +77,7 @@ function SessionContent() {
   const difficulty = (searchParams.get('difficulty') as Difficulty) ?? 'Medium';
 
   // ── Mode detection (stable for the lifetime of this page) ────────────────────
-  const isLive = getIsLive();
+  const isLive = false;
 
   // Pre-load mock data (only used in demo mode, empty array in live mode)
   const mockQData = useRef<MockQuestion[]>(

--- a/frontend/app/(app)/jobs/page.tsx
+++ b/frontend/app/(app)/jobs/page.tsx
@@ -1,11 +1,13 @@
 'use client';
 
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
+
 import KanbanBoard from '../../components/jobs/KanbanBoard';
 import { useJobs, useCreateJob } from '../../hooks/useJobs';
 import demoJobs from '../../lib/demoJobs';
+import Modal from '../../components/ui/Modal';
 
-const isDemo = process.env.NEXT_PUBLIC_APP_MODE === 'demo';
+const demoMode = process.env.NEXT_PUBLIC_APP_MODE === 'demo';
 
 function DemoSeeder() {
   const { data: jobs } = useJobs();
@@ -13,7 +15,7 @@ function DemoSeeder() {
   const seeded = useRef(false);
 
   useEffect(() => {
-    if (!isDemo || seeded.current || !jobs || jobs.length > 0) return;
+    if (!demoMode || seeded.current || !jobs || jobs.length > 0) return;
     demoJobs.forEach((job) => createJob.mutate(job));
     seeded.current = true;
   }, [jobs, createJob]);
@@ -22,18 +24,51 @@ function DemoSeeder() {
 }
 
 export default function JobsPage() {
+  const [showDemoModal, setShowDemoModal] = useState(demoMode);
+
   return (
     <div className="flex flex-col h-full gap-5">
       <div className="shrink-0">
-        <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-50">
-          Job Tracker
-        </h1>
+        <div className="flex items-center gap-2.5">
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-50">
+            Job Tracker
+          </h1>
+          {demoMode && (
+            <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-[#EEF0FD] text-[#3948CF] dark:bg-indigo-900/30 dark:text-indigo-400">
+              Demo
+            </span>
+          )}
+        </div>
         <p className="text-sm text-gray-500 dark:text-gray-400 mt-0.5">
           Track and manage all your job applications in one place.
         </p>
       </div>
-      {isDemo && <DemoSeeder />}
+      {demoMode && <DemoSeeder />}
       <KanbanBoard />
+
+      <Modal
+        open={showDemoModal}
+        onClose={() => setShowDemoModal(false)}
+        title="You're viewing a demo"
+      >
+        <div className="flex flex-col items-center text-center gap-4 py-1">
+          <img src="/logo-light.png" alt="Prepify" className="h-6 w-auto dark:hidden" />
+          <img src="/logo-dark.png" alt="Prepify" className="h-6 w-auto hidden dark:block" />
+          <p className="text-sm text-gray-600 dark:text-gray-300 leading-relaxed">
+            The <span className="font-semibold">Job Tracker</span> is running in demo mode.
+            The job cards you see are pre-seeded sample data — no real applications are
+            being tracked. In the full version, you can add, move, and manage your own
+            job applications across the hiring pipeline.
+          </p>
+          <button
+            onClick={() => setShowDemoModal(false)}
+            className="w-full py-2.5 rounded-lg text-sm font-medium text-white transition-opacity hover:opacity-90"
+            style={{ backgroundColor: '#3948CF' }}
+          >
+            Got it, explore the demo
+          </button>
+        </div>
+      </Modal>
     </div>
   );
 }

--- a/frontend/app/(app)/layout.tsx
+++ b/frontend/app/(app)/layout.tsx
@@ -54,11 +54,13 @@ export default function AppShellLayout({ children }: { children: React.ReactNode
       {sidebarOpen && (
         <aside className="w-56 bg-white dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700 flex flex-col shrink-0">
           <div className="pl-5 pr-4 py-4 flex items-center border-b border-gray-100 dark:border-gray-700">
-            <img
-              src={isDark ? '/logo-dark.png' : '/logo-light.png'}
-              alt="Prepify"
-              className="h-6 w-auto max-w-full"
-            />
+            <Link href="/">
+              <img
+                src={isDark ? '/logo-dark.png' : '/logo-light.png'}
+                alt="Prepify"
+                className="h-6 w-auto max-w-full"
+              />
+            </Link>
           </div>
 
           <nav className="flex-1 p-3 space-y-0.5">

--- a/frontend/app/(app)/resume/page.tsx
+++ b/frontend/app/(app)/resume/page.tsx
@@ -22,8 +22,19 @@ import ScoreBreakdown from '../../components/resume/ScoreBreakdown';
 import KeywordTags from '../../components/resume/KeywordTags';
 import SuggestionCard from '../../components/resume/SuggestionCard';
 import ApiKeyModal from '../../components/resume/ApiKeyModal';
+import Modal from '../../components/ui/Modal';
 import { extractResumeText } from '../../lib/extractResumeText';
 import { analyzeResume, type AnalyzeResult } from '../../lib/api/resume';
+import { DEMO_RESUME_RESULT } from '../../lib/resume/mockData';
+
+// Demo (deployed) → simulation only. Local dev → real API + key prompt.
+function getIsLive(): boolean {
+  if (typeof window === 'undefined') return false;
+  return (
+    process.env.NODE_ENV === 'development' ||
+    window.location.hostname === 'localhost'
+  );
+}
 
 // Derive five breakdown scores from the single overall score.
 // Offsets are intentionally small to keep bars believable.
@@ -79,7 +90,21 @@ export default function ResumePage() {
     }
   });
 
+  // Stable for the lifetime of the page — same logic as the interview session.
+  const isLive = getIsLive();
+
+  const [showDemoModal, setShowDemoModal] = useState(!isLive);
+
   const canAnalyze = !!file && jobDescription.trim().length > 0;
+
+  // Demo mode: return hardcoded results after a short delay so the UI feels real.
+  const runDemoAnalysis = async () => {
+    setIsAnalyzing(true);
+    setError(null);
+    await new Promise((resolve) => setTimeout(resolve, 1800));
+    setResult(DEMO_RESUME_RESULT);
+    setIsAnalyzing(false);
+  };
 
   const runAnalysis = async () => {
     if (!file) return;
@@ -115,6 +140,13 @@ export default function ResumePage() {
 
   const handleAnalyze = () => {
     if (!canAnalyze) return;
+
+    // Demo mode — skip API key entirely and run the simulation.
+    if (!isLive) {
+      runDemoAnalysis();
+      return;
+    }
+
     try {
       if (!localStorage.getItem('prepify_api_key')) {
         setShowApiKeyModal(true);
@@ -174,9 +206,16 @@ export default function ResumePage() {
     <div className="flex flex-col gap-5">
       {/* Page header */}
       <div className="shrink-0">
-        <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-50">
-          Resume Analyzer
-        </h1>
+        <div className="flex items-center gap-2">
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-50">
+            Resume Analyzer
+          </h1>
+          {!isLive && (
+            <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-[#EEF0FD] text-[#3948CF] dark:bg-indigo-900/30 dark:text-indigo-400">
+              Demo
+            </span>
+          )}
+        </div>
         <p className="text-sm text-gray-500 dark:text-gray-400 mt-0.5">
           Upload your resume and paste the job description. We&apos;ll suggest
           tailored experience lines, a summary, and skills to improve fit.
@@ -341,7 +380,7 @@ export default function ResumePage() {
               </p>
             )}
 
-            {hasApiKey && !result && !error && (
+            {isLive && hasApiKey && !result && !error && (
               <div className="text-center -mt-1">
                 <button
                   onClick={handleChangeApiKey}
@@ -425,11 +464,45 @@ export default function ResumePage() {
         </div>
       </div>
 
-      <ApiKeyModal
-        open={showApiKeyModal}
-        onClose={() => setShowApiKeyModal(false)}
-        onSave={handleApiKeySave}
-      />
+      {isLive && (
+        <ApiKeyModal
+          open={showApiKeyModal}
+          onClose={() => setShowApiKeyModal(false)}
+          onSave={handleApiKeySave}
+        />
+      )}
+
+      {/* Demo notice — shown automatically on first load in demo mode */}
+      <Modal
+        open={showDemoModal}
+        onClose={() => setShowDemoModal(false)}
+        title="You're viewing a demo"
+      >
+        <div className="flex flex-col items-center text-center gap-4">
+          <img src="/logo-light.png" alt="Prepify" className="h-6 w-auto dark:hidden" />
+          <img src="/logo-dark.png" alt="Prepify" className="h-6 w-auto hidden dark:block" />
+
+          <p className="text-sm text-gray-600 dark:text-gray-300 leading-relaxed">
+            The results shown here are <span className="font-semibold text-gray-900 dark:text-gray-100">pre-built examples</span>, not real AI output. This demo lets you explore the full Resume Analyzer experience — score breakdown, matched keywords, suggestions — without needing an API key.
+          </p>
+
+          <p className="text-sm text-gray-500 dark:text-gray-400 leading-relaxed">
+            In the live version, your actual resume and job description are sent to AI, which returns genuine personalised feedback.
+          </p>
+
+          <p className="text-xs text-gray-400 dark:text-gray-500">
+            Upload any file and paste any job description — you&apos;ll see the same demo result after a short delay.
+          </p>
+
+          <button
+            onClick={() => setShowDemoModal(false)}
+            className="w-full py-2.5 rounded-xl text-sm font-semibold text-white transition-opacity hover:opacity-90"
+            style={{ backgroundColor: '#3948CF' }}
+          >
+            Got it, explore the demo
+          </button>
+        </div>
+      </Modal>
     </div>
   );
 }

--- a/frontend/app/components/jobs/KanbanBoard.tsx
+++ b/frontend/app/components/jobs/KanbanBoard.tsx
@@ -122,24 +122,24 @@ export default function KanbanBoard() {
 
   return (
     <div className="flex flex-col h-full gap-5">
-      <div className="flex items-center justify-between flex-shrink-0">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between flex-shrink-0">
         <SearchInput
           value={search}
           onChange={setSearch}
           placeholder="Search by company or role..."
         />
-        <div className="flex flex-col items-end gap-1">
+        <div className="flex flex-col gap-1">
           <button
             onClick={() => setModalOpen(true)}
             disabled={isDemo && limitReached}
-            className="flex items-center gap-2 px-4 py-2 text-sm font-medium text-white rounded-lg transition-opacity hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed"
+            className="flex items-center justify-center gap-2 px-4 py-2 text-sm font-medium text-white rounded-lg transition-opacity hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed"
             style={{ backgroundColor: '#3948CF' }}
           >
             <Plus className="w-4 h-4" />
             Add Application
           </button>
           {isDemo && limitReached && (
-            <p className="text-xs text-amber-500">
+            <p className="text-xs text-amber-500 text-center sm:text-right">
               Demo limit reached ({count}/5 today). Resets tomorrow.
             </p>
           )}
@@ -147,7 +147,7 @@ export default function KanbanBoard() {
       </div>
 
       <DndContext sensors={sensors} onDragStart={handleDragStart} onDragEnd={handleDragEnd}>
-        <div className="flex gap-3 flex-1 items-start">
+        <div className="flex gap-3 flex-1 items-start overflow-x-auto pb-2 -mx-1 px-1">
           {COLUMNS.map((col) => (
             <KanbanColumn
               key={col.id}

--- a/frontend/app/components/jobs/KanbanColumn.tsx
+++ b/frontend/app/components/jobs/KanbanColumn.tsx
@@ -24,7 +24,7 @@ export default function KanbanColumn({ column, jobs, activeId, onDelete }: Kanba
   const { setNodeRef, isOver } = useDroppable({ id: column.id });
 
   return (
-    <div className="flex flex-col flex-1 min-w-0">
+    <div className="flex flex-col flex-1 min-w-[200px] sm:min-w-0">
       <div className={`flex items-center justify-between px-3 py-2.5 rounded-t-xl ${column.headerBg}`}>
         <span className="text-sm font-semibold text-gray-700 dark:text-gray-200">
           {column.label}

--- a/frontend/app/components/ui/Modal.tsx
+++ b/frontend/app/components/ui/Modal.tsx
@@ -34,14 +34,14 @@ export default function Modal({ open, onClose, title, children }: ModalProps) {
         onClick={onClose}
       />
       <div className="relative bg-white dark:bg-gray-800 rounded-2xl shadow-xl w-full max-w-md mx-4 p-6">
-        <div className="flex items-center justify-between mb-5">
-          <h2 id="modal-title" className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+        <div className="relative flex items-center justify-center mb-5">
+          <h2 id="modal-title" className="text-lg font-semibold text-center text-gray-900 dark:text-gray-100">
             {title}
           </h2>
           <button
             onClick={onClose}
             aria-label="Close modal"
-            className="p-1.5 rounded-md text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+            className="absolute right-0 p-1.5 rounded-md text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
           >
             <X className="w-4 h-4" />
           </button>

--- a/frontend/app/lib/resume/mockData.ts
+++ b/frontend/app/lib/resume/mockData.ts
@@ -1,0 +1,81 @@
+import type { AnalyzeResult } from '../api/resume';
+
+/**
+ * Demo result returned in non-local (deployed) builds.
+ * Lets visitors explore the full Resume Analyzer UI without needing an API key.
+ *
+ * IMPORTANT: Do NOT remove this — it powers the public demo.
+ * For the real AI analysis, the local/Electron build calls the backend API.
+ */
+export const DEMO_RESUME_RESULT: AnalyzeResult = {
+  score: 72,
+  matchedKeywords: [
+    'React',
+    'TypeScript',
+    'Node.js',
+    'REST API',
+    'Git',
+    'Agile',
+    'PostgreSQL',
+    'Unit Testing',
+    'JavaScript',
+    'CI/CD',
+  ],
+  missingKeywords: [
+    'Docker',
+    'Kubernetes',
+    'AWS',
+    'GraphQL',
+    'Redis',
+    'Microservices',
+    'System Design',
+  ],
+  keywordFrequency: [],
+  suggestions: [
+    {
+      id: '1',
+      category: 'Summary',
+      text: 'Results-driven Software Engineer with 3+ years of experience building scalable web applications using React, TypeScript, and Node.js. Adept at delivering high-quality code in Agile environments and optimising system performance for production workloads.',
+    },
+    {
+      id: '2',
+      category: 'Experience',
+      text: 'Engineered and deployed 3 production-grade REST APIs in Node.js and TypeScript, cutting average response latency by 40% through query optimisation and caching strategies.',
+    },
+    {
+      id: '3',
+      category: 'Experience',
+      text: 'Led migration of a monolithic frontend to a React 18 component library, improving page-load performance by 35% and enabling independent team deployments.',
+    },
+    {
+      id: '4',
+      category: 'Experience',
+      text: 'Collaborated in two-week Agile sprints, consistently shipping features on schedule while maintaining 90%+ unit-test coverage across the codebase.',
+    },
+    {
+      id: '5',
+      category: 'Skills',
+      text: 'Docker & container orchestration (Kubernetes)',
+    },
+    {
+      id: '6',
+      category: 'Skills',
+      text: 'AWS (EC2, S3, Lambda)',
+    },
+    {
+      id: '7',
+      category: 'Skills',
+      text: 'GraphQL API design',
+    },
+    {
+      id: '8',
+      category: 'Skills',
+      text: 'Redis caching',
+    },
+    {
+      id: '9',
+      category: 'Education',
+      text: 'Consider listing relevant coursework such as Distributed Systems, Cloud Computing, or Database Internals to align with the role\'s infrastructure focus.',
+    },
+  ],
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
       ],
       "devDependencies": {
         "concurrently": "^8.0.0",
+        "cross-env": "^10.1.0",
         "rimraf": "^5.0.0"
       }
     },
@@ -448,6 +449,13 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@epic-web/invariant": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
+      "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.3",
@@ -4667,6 +4675,24 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-env": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.1.0.tgz",
+      "integrity": "sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@epic-web/invariant": "^1.0.0",
+        "cross-spawn": "^7.0.6"
+      },
+      "bin": {
+        "cross-env": "dist/bin/cross-env.js",
+        "cross-env-shell": "dist/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/cross-spawn": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "A career-focused platform featuring an AI-powered resume analyzer, job application tracking, and mock interviews with AI.",
   "main": "index.js",
   "scripts": {
-    "dev": "concurrently \"npm run dev --workspace=backend\" \"npm run dev --workspace=frontend\"",
+    "dev": "cross-env NODE_NO_WARNINGS=1 concurrently \"npm run dev --workspace=backend\" \"npm run dev --workspace=frontend\"",
     "build": "npm run build --workspace=backend && npm run build --workspace=frontend",
     "clean": "npm run clean --workspace=backend --if-present && npm run clean --workspace=frontend --if-present"
   },
@@ -15,6 +15,7 @@
   ],
   "devDependencies": {
     "concurrently": "^8.0.0",
+    "cross-env": "^10.1.0",
     "rimraf": "^5.0.0"
   },
   "repository": {


### PR DESCRIPTION
- Add demo badge + auto-open modal to Resume Analyzer, Mock Interview, and Job Tracker pages to inform users they're viewing simulated data
- Add DEMO_RESUME_RESULT mock data for deployed demo simulation
- Center modal titles across all modals (Modal.tsx layout update)
- Replace Sparkles icon with Prepify logo in all demo modals
- Make Kanban board horizontally scrollable on mobile/tablet with min-width columns; stack search/add-button bar on small screens
- Make logo in sidebar clickable, linking back to home page
- Add cross-env NODE_NO_WARNINGS=1 to dev script for Windows
- Fix voice input mic button placement (embedded inside textarea)
- Fix dark mode mic button visibility using Tailwind dark: variants

