### PR TITLE
feat: job tracker improvements — detail modal, layout scroll fix

### DIFF
--- a/frontend/app/(app)/jobs/page.tsx
+++ b/frontend/app/(app)/jobs/page.tsx
@@ -28,7 +28,7 @@ export default function JobsPage() {
   const [showDemoModal, setShowDemoModal] = useState(demoMode);
 
   return (
-    <div className="flex flex-col h-full gap-5">
+    <div className="flex flex-col gap-5">
       <div className="shrink-0">
         <div className="flex items-center gap-2.5">
           <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-50">

--- a/frontend/app/(app)/layout.tsx
+++ b/frontend/app/(app)/layout.tsx
@@ -40,9 +40,9 @@ export default function AppShellLayout({ children }: { children: React.ReactNode
   const isDark = theme === 'dark';
 
   return (
-    <div className="flex h-screen bg-gray-50 dark:bg-gray-900 overflow-hidden">
+    <div className="flex min-h-screen bg-gray-50 dark:bg-gray-900">
       {sidebarOpen && (
-        <aside className="w-56 bg-white dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700 flex flex-col shrink-0">
+        <aside className="w-56 bg-white dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700 flex flex-col shrink-0 sticky top-0 h-screen">
           <div className="pl-5 pr-4 py-4 flex items-center border-b border-gray-100 dark:border-gray-700">
             <Link href="/">
               <Image
@@ -77,8 +77,8 @@ export default function AppShellLayout({ children }: { children: React.ReactNode
         </aside>
       )}
 
-      <div className="flex-1 flex flex-col overflow-hidden">
-        <div className="px-3 py-2 bg-white dark:bg-gray-800 border-b border-gray-100 dark:border-gray-700 flex items-center justify-between">
+      <div className="flex-1 flex flex-col min-w-0">
+        <div className="sticky top-0 z-10 px-3 py-2 bg-white dark:bg-gray-800 border-b border-gray-100 dark:border-gray-700 flex items-center justify-between">
           <button
             onClick={() => setSidebarOpen((v: boolean) => !v)}
             aria-label="Toggle sidebar"
@@ -95,7 +95,7 @@ export default function AppShellLayout({ children }: { children: React.ReactNode
           </button>
         </div>
 
-        <main className="flex-1 overflow-auto p-6">
+        <main className="flex-1 p-6">
           {children}
         </main>
       </div>

--- a/frontend/app/components/jobs/JobCard.tsx
+++ b/frontend/app/components/jobs/JobCard.tsx
@@ -9,9 +9,10 @@ interface JobCardProps {
   job: Job;
   onDelete: (id: string) => void;
   isDraggingOriginal: boolean;
+  onViewDetails: (job: Job) => void;
 }
 
-export default function JobCard({ job, onDelete, isDraggingOriginal }: JobCardProps) {
+export default function JobCard({ job, onDelete, isDraggingOriginal, onViewDetails }: JobCardProps) {
   const { attributes, listeners, setNodeRef, transform } = useDraggable({ id: job.id });
 
   return (
@@ -25,7 +26,7 @@ export default function JobCard({ job, onDelete, isDraggingOriginal }: JobCardPr
       {...listeners}
       className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 p-3.5 shadow-sm select-none touch-none cursor-grab active:cursor-grabbing hover:shadow-md transition-shadow"
     >
-      <JobCardContent job={job} onDelete={onDelete} />
+      <JobCardContent job={job} onDelete={onDelete} onViewDetails={onViewDetails} />
     </div>
   );
 }

--- a/frontend/app/components/jobs/JobCardContent.tsx
+++ b/frontend/app/components/jobs/JobCardContent.tsx
@@ -8,9 +8,10 @@ interface JobCardContentProps {
   job: Job;
   onDelete?: (id: string) => void;
   showMenu?: boolean;
+  onViewDetails?: (job: Job) => void;
 }
 
-export default function JobCardContent({ job, onDelete, showMenu = true }: JobCardContentProps) {
+export default function JobCardContent({ job, onDelete, showMenu = true, onViewDetails }: JobCardContentProps) {
   const [menuOpen, setMenuOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
 
@@ -26,7 +27,7 @@ export default function JobCardContent({ job, onDelete, showMenu = true }: JobCa
   }, [menuOpen]);
 
   return (
-    <div className="flex flex-col gap-2">
+    <div className="flex flex-col gap-2" onClick={() => onViewDetails?.(job)}>
       <div className="flex items-start justify-between gap-2">
         <div className="flex items-center gap-2.5 min-w-0">
           <div

--- a/frontend/app/components/jobs/JobDetailsModal.tsx
+++ b/frontend/app/components/jobs/JobDetailsModal.tsx
@@ -1,0 +1,120 @@
+'use client';
+
+import { MapPin, DollarSign, Calendar, ExternalLink, Briefcase, FileText } from 'lucide-react';
+import Modal from '@/components/ui/Modal';
+import type { Job } from '@/types/job';
+
+interface JobDetailsModalProps {
+  job: Job | null;
+  onClose: () => void;
+}
+
+const STATUS_STYLES: Record<string, string> = {
+  Wishlist: 'bg-pink-100 text-pink-700 dark:bg-pink-900/40 dark:text-pink-300',
+  Applied: 'bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300',
+  Interview: 'bg-purple-100 text-purple-700 dark:bg-purple-900/40 dark:text-purple-300',
+  Offer: 'bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300',
+  Rejected: 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300',
+};
+
+export default function JobDetailsModal({ job, onClose }: JobDetailsModalProps) {
+  if (!job) return null;
+
+  return (
+    <Modal open={!!job} onClose={onClose} title="Job Details">
+      <div className="flex flex-col gap-5">
+
+        {/* Header */}
+        <div className="flex items-center gap-3">
+          <div
+            className="w-12 h-12 rounded-xl flex items-center justify-center text-white text-lg font-bold flex-shrink-0"
+            style={{ backgroundColor: '#3948CF' }}
+          >
+            {job.company.charAt(0).toUpperCase()}
+          </div>
+          <div className="min-w-0">
+            <h3 className="text-base font-semibold text-gray-900 dark:text-gray-100 truncate">
+              {job.role}
+            </h3>
+            <p className="text-sm text-gray-500 dark:text-gray-400 truncate">{job.company}</p>
+          </div>
+          <span className={`ml-auto text-xs font-semibold px-2.5 py-1 rounded-full flex-shrink-0 ${STATUS_STYLES[job.status] ?? 'bg-gray-100 text-gray-600'}`}>
+            {job.status}
+          </span>
+        </div>
+
+        <div className="h-px bg-gray-100 dark:bg-gray-700" />
+
+        {/* Details grid */}
+        <div className="grid grid-cols-2 gap-3">
+          {job.location && (
+            <div className="flex items-start gap-2">
+              <MapPin className="w-4 h-4 text-gray-400 mt-0.5 flex-shrink-0" />
+              <div>
+                <p className="text-xs text-gray-400 dark:text-gray-500">Location</p>
+                <p className="text-sm text-gray-700 dark:text-gray-200">{job.location}</p>
+              </div>
+            </div>
+          )}
+          {job.salary && (
+            <div className="flex items-start gap-2">
+              <DollarSign className="w-4 h-4 text-gray-400 mt-0.5 flex-shrink-0" />
+              <div>
+                <p className="text-xs text-gray-400 dark:text-gray-500">Salary</p>
+                <p className="text-sm text-gray-700 dark:text-gray-200">{job.salary}</p>
+              </div>
+            </div>
+          )}
+          <div className="flex items-start gap-2">
+            <Calendar className="w-4 h-4 text-gray-400 mt-0.5 flex-shrink-0" />
+            <div>
+              <p className="text-xs text-gray-400 dark:text-gray-500">Applied</p>
+              <p className="text-sm text-gray-700 dark:text-gray-200">
+                {new Date(job.appliedAt).toLocaleDateString('en-US', {
+                  month: 'short', day: 'numeric', year: 'numeric',
+                })}
+              </p>
+            </div>
+          </div>
+          <div className="flex items-start gap-2">
+            <Briefcase className="w-4 h-4 text-gray-400 mt-0.5 flex-shrink-0" />
+            <div>
+              <p className="text-xs text-gray-400 dark:text-gray-500">Status</p>
+              <p className="text-sm text-gray-700 dark:text-gray-200">{job.status}</p>
+            </div>
+          </div>
+        </div>
+
+        {/* Notes */}
+        {job.notes && (
+          <>
+            <div className="h-px bg-gray-100 dark:bg-gray-700" />
+            <div className="flex items-start gap-2">
+              <FileText className="w-4 h-4 text-gray-400 mt-0.5 flex-shrink-0" />
+              <div>
+                <p className="text-xs text-gray-400 dark:text-gray-500 mb-1">Notes</p>
+                <p className="text-sm text-gray-700 dark:text-gray-300 leading-relaxed whitespace-pre-wrap max-h-32 overflow-y-auto pr-1">
+                  {job.notes}
+                </p>
+              </div>
+            </div>
+          </>
+        )}
+
+        {/* View Posting button */}
+        {job.jobUrl && (
+          <a
+            href={job.jobUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center justify-center gap-2 w-full py-2.5 rounded-lg text-sm font-medium text-white transition-opacity hover:opacity-90"
+            style={{ backgroundColor: '#3948CF' }}
+          >
+            <ExternalLink className="w-4 h-4" />
+            View Job Posting
+          </a>
+        )}
+      </div>
+    </Modal>
+  );
+}

--- a/frontend/app/components/jobs/KanbanBoard.tsx
+++ b/frontend/app/components/jobs/KanbanBoard.tsx
@@ -17,6 +17,8 @@ import KanbanColumn, { type ColumnConfig } from './KanbanColumn';
 import JobCardContent from './JobCardContent';
 import AddJobModal from './AddJobModal';
 import SearchInput from '@/components/ui/SearchInput';
+import { Job } from '@/types/job';
+import JobDetailsModal from './JobDetailsModal';
 
 const isDemo = process.env.NEXT_PUBLIC_APP_MODE === 'demo';
 
@@ -65,6 +67,7 @@ const COLUMNS: ColumnConfig[] = [
 
 export default function KanbanBoard() {
   const { data: jobs = [], isLoading, isError } = useJobs();
+  const [selectedJob, setSelectedJob] = useState<Job | null>(null);
   const createJob = useCreateJob();
   const updateJob = useUpdateJob();
   const deleteJob = useDeleteJob();
@@ -104,6 +107,10 @@ export default function KanbanBoard() {
     updateJob.mutate({ id: jobId, data: { status: newStatus } });
   }
 
+  function onViewDetails(job: Job) {
+    setSelectedJob(job);
+  }
+
   if (isLoading) {
     return (
       <div className="flex-1 flex items-center justify-center text-sm text-gray-400 dark:text-gray-500">
@@ -121,7 +128,7 @@ export default function KanbanBoard() {
   }
 
   return (
-    <div className="flex flex-col h-full gap-5">
+    <div className="flex flex-col gap-5">
       <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between flex-shrink-0">
         <SearchInput
           value={search}
@@ -155,6 +162,7 @@ export default function KanbanBoard() {
               jobs={displayed.filter((j) => j.status === col.id)}
               activeId={activeId}
               onDelete={(id) => deleteJob.mutate(id)}
+              onViewDetails={onViewDetails}
             />
           ))}
         </div>
@@ -179,6 +187,11 @@ export default function KanbanBoard() {
           })
         }
         isPending={createJob.isPending}
+      />
+      <JobDetailsModal
+        job={selectedJob}
+        onClose={() => setSelectedJob(null)}
+        
       />
     </div>
   );

--- a/frontend/app/components/jobs/KanbanColumn.tsx
+++ b/frontend/app/components/jobs/KanbanColumn.tsx
@@ -18,9 +18,10 @@ interface KanbanColumnProps {
   jobs: Job[];
   activeId: string | null;
   onDelete: (id: string) => void;
+  onViewDetails: (job: Job) => void;
 }
 
-export default function KanbanColumn({ column, jobs, activeId, onDelete }: KanbanColumnProps) {
+export default function KanbanColumn({ column, jobs, activeId, onDelete , onViewDetails}: KanbanColumnProps) {
   const { setNodeRef, isOver } = useDroppable({ id: column.id });
 
   return (
@@ -46,9 +47,12 @@ export default function KanbanColumn({ column, jobs, activeId, onDelete }: Kanba
             job={job}
             onDelete={onDelete}
             isDraggingOriginal={activeId === job.id}
+            onViewDetails={onViewDetails}
           />
         ))}
       </div>
     </div>
   );
 }
+
+

--- a/frontend/app/hooks/useDemoLimit.ts
+++ b/frontend/app/hooks/useDemoLimit.ts
@@ -28,26 +28,25 @@ function writeState(state: DemoLimitState) {
   localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
 }
 
-export function useDemoLimit() {
-  const [state, setState] = useState<DemoLimitState>({
-    date: todayStr(),
-    count: 0,
-    addedIds: [],
-  });
+let pendingStaleIds: string[] = [];
 
-  useEffect(() => {
+export function useDemoLimit() {
+  const [state, setState] = useState<DemoLimitState>(() => {
     const current = readState();
     if (current.date !== todayStr()) {
-      // New day: silently delete jobs added yesterday
-      current.addedIds.forEach((id) => {
-        jobsApi.delete(id).catch(() => {});
-      });
+      pendingStaleIds = current.addedIds;
       const reset: DemoLimitState = { date: todayStr(), count: 0, addedIds: [] };
       writeState(reset);
-      setState(reset);
-    } else {
-      setState(current);
+      return reset;
     }
+    return current;
+  });
+
+  // Side-effect only: delete stale jobs from the previous day
+  useEffect(() => {
+    const ids = pendingStaleIds;
+    pendingStaleIds = [];
+    ids.forEach((id) => jobsApi.delete(id).catch(() => {}));
   }, []);
 
   const recordAdd = useCallback((id: string) => {


### PR DESCRIPTION
- Add JobDetailsModal with company header, status badge, details grid, notes, and job URL button
- Wire onViewDetails through KanbanBoard → KanbanColumn → JobCard → JobCardContent
- Fix layout to use browser-native scroll (sticky sidebar + topbar, no overflow-auto on main)
- Remove in-column scrollbars from Kanban board
- Refactor useDemoLimit to use lazy useState initializer instead of setState-in-effect pattern